### PR TITLE
Add macOS ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-native:
     strategy:
       fail-fast: false
       matrix:
@@ -19,7 +19,7 @@ jobs:
             artifact-name: Linux
             target: all
           - os: macOS-11
-            artifact-name: macOS
+            artifact-name: macOS x86_64
             target: all
 
     name: "${{ matrix.artifact-name }}"
@@ -45,6 +45,35 @@ jobs:
       - name: test
         working-directory: build
         run: ctest -C RelWithDebInfo --output-on-failure
+
+      - name: install
+        run: cmake --install build --config RelWithDebInfo --prefix pkg
+
+      - uses: actions/upload-artifact@v3.1.1
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: pkg
+
+  build-cross:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS-11
+            artifact-name: macOS arm64
+            target: all
+            cmake-config-env-vars: CFLAGS="$CFLAGS -arch arm64" CXXFLAGS="$CXXFLAGS -arch arm64"
+
+    name: "${{ matrix.artifact-name }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: configure
+        run: ${{ matrix.cmake-config-env-vars }} cmake -B build -S .
+
+      - name: build
+        run: cmake --build build --target Sleipnir --config RelWithDebInfo --parallel $(nproc)
 
       - name: install
         run: cmake --install build --config RelWithDebInfo --prefix pkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ target_include_directories(Sleipnir
                            ${CMAKE_CURRENT_SOURCE_DIR}/src
                            ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/llvm/include)
 
+option(INSTALL_SLEIPNIR "Install Sleipnir" ON)
+
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 set_target_properties(Sleipnir PROPERTIES DEBUG_POSTFIX "d")
@@ -118,17 +120,21 @@ target_include_directories(Sleipnir
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                            $<INSTALL_INTERFACE:include/Sleipnir>)
 
-install(TARGETS Sleipnir EXPORT Sleipnir DESTINATION lib)
-install(DIRECTORY include/ DESTINATION "include/Sleipnir")
+if (INSTALL_SLEIPNIR)
+  install(TARGETS Sleipnir EXPORT Sleipnir DESTINATION lib)
+  install(DIRECTORY include/ DESTINATION "include/Sleipnir")
+endif()
 
 target_include_directories(Sleipnir
                            INTERFACE
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<INSTALL_INTERFACE:include>)
 
-install(EXPORT Sleipnir
-  FILE Sleipnir.cmake
-  DESTINATION lib/cmake/Sleipnir)
+if (INSTALL_SLEIPNIR)
+  install(EXPORT Sleipnir
+    FILE Sleipnir.cmake
+    DESTINATION lib/cmake/Sleipnir)
+endif()
 
 include(CMakePackageConfigHelpers)
 
@@ -165,6 +171,8 @@ endif()
 # GoogleTest dependency (static linkage)
 set(BUILD_SHARED_LIBS_SAVE ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
+option(INSTALL_GMOCK "Install GoogleTest's GMock" OFF)
+option(INSTALL_GTEST "Install GoogleTest's GTest" OFF)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git


### PR DESCRIPTION
Also skip installation of GMock and GTest (the macOS arm64 build fails otherwise), and add a flag that lets the same be done for Sleipnir.