### PR TITLE
Add autodiff instance reuse tests

### DIFF
--- a/test/src/autodiff/GradientTest.cpp
+++ b/test/src/autodiff/GradientTest.cpp
@@ -526,3 +526,18 @@ TEST(GradientTest, Gradient) {
                 .Calculate()
                 .coeff(0));
 }
+
+TEST(GradientTest, Reuse) {
+  sleipnir::autodiff::Variable a = 10;
+  sleipnir::autodiff::Variable b = 20;
+  sleipnir::autodiff::Variable x = a * b;
+
+  sleipnir::autodiff::Gradient gradient{x, a};
+
+  auto g = gradient.Calculate();
+  EXPECT_EQ(20.0, g.coeff(0));
+
+  b = 10;
+  g = gradient.Calculate();
+  EXPECT_EQ(10.0, g.coeff(0));
+}

--- a/test/src/autodiff/HessianTest.cpp
+++ b/test/src/autodiff/HessianTest.cpp
@@ -174,3 +174,31 @@ TEST(HessianTest, SumOfSquaredResiduals) {
   EXPECT_EQ(-2.0, H(4, 3));
   EXPECT_EQ(2.0, H(4, 4));
 }
+
+TEST(HessianTest, DISABLED_Reuse) {
+  sleipnir::autodiff::Variable y;
+  sleipnir::autodiff::VectorXvar x{1};
+
+  // y = x³
+  x << 1;
+  y = x(0) * x(0) * x(0);
+
+  sleipnir::autodiff::Hessian hessian{y, x};
+
+  // d²y/dx² = 6x
+  // H = 6
+  Eigen::MatrixXd H = hessian.Calculate();
+
+  EXPECT_EQ(1, H.rows());
+  EXPECT_EQ(1, H.cols());
+  EXPECT_DOUBLE_EQ(6.0, H(0, 0));
+
+  x << 2;
+  // d²y/dx² = 6x
+  // H = 12
+  H = hessian.Calculate();
+
+  EXPECT_EQ(1, H.rows());
+  EXPECT_EQ(1, H.cols());
+  EXPECT_DOUBLE_EQ(12.0, H(0, 0));
+}

--- a/test/src/autodiff/JacobianTest.cpp
+++ b/test/src/autodiff/JacobianTest.cpp
@@ -133,3 +133,33 @@ TEST(JacobianTest, NonSquare) {
   EXPECT_DOUBLE_EQ(3.0, J(0, 1));
   EXPECT_DOUBLE_EQ(-5.0, J(0, 2));
 }
+
+TEST(JacobianTest, DISABLED_Reuse) {
+  sleipnir::autodiff::VectorXvar y{1, 1};
+  sleipnir::autodiff::VectorXvar x{2};
+
+  // y = [x₁x₂]
+  x << 1, 2;
+  y(0) = x(0) * x(1);
+
+  sleipnir::autodiff::Jacobian jacobian{y, x};
+
+  // dy/dx = [x₂  x₁]
+  // dy/dx = [2  1]
+  Eigen::MatrixXd J = jacobian.Calculate();
+
+  EXPECT_EQ(1, J.rows());
+  EXPECT_EQ(2, J.cols());
+  EXPECT_DOUBLE_EQ(2.0, J(0, 0));
+  EXPECT_DOUBLE_EQ(1.0, J(0, 1));
+
+  x << 2, 1;
+  // dy/dx = [x₁  x₂]
+  // dy/dx = [1  2]
+  J = jacobian.Calculate();
+
+  EXPECT_EQ(1, J.rows());
+  EXPECT_EQ(2, J.cols());
+  EXPECT_DOUBLE_EQ(1.0, J(0, 0));
+  EXPECT_DOUBLE_EQ(2.0, J(0, 1));
+}


### PR DESCRIPTION
The Jacobian and Hessian ones fail, so those are disabled until we can fix the autodiff implementation.