### PR TITLE
Use Variable for scalars in OptimizationProblem API

### DIFF
--- a/benchmarks/scalability/CartPole/Sleipnir.cpp
+++ b/benchmarks/scalability/CartPole/Sleipnir.cpp
@@ -153,7 +153,7 @@ sleipnir::OptimizationProblem CartPoleSleipnir(units::second_t dt, int N) {
   }
 
   // Minimize sum squared inputs
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N; ++k) {
     J += U.Col(k).T() * U.Col(k);
   }

--- a/benchmarks/scalability/Flywheel/Sleipnir.cpp
+++ b/benchmarks/scalability/Flywheel/Sleipnir.cpp
@@ -29,7 +29,7 @@ sleipnir::OptimizationProblem FlywheelSleipnir(units::second_t dt, int N) {
 
   // Cost function - minimize error
   Eigen::Matrix<double, 1, 1> r{10.0};
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N + 1; ++k) {
     J += ((r - X.Col(k)).T() * (r - X.Col(k)));
   }

--- a/examples/CurrentManager/src/CurrentManager.cpp
+++ b/examples/CurrentManager/src/CurrentManager.cpp
@@ -16,8 +16,8 @@ CurrentManager::CurrentManager(
     m_desiredCurrents(row) = 0.0;
   }
 
-  sleipnir::VariableMatrix J = 0.0;
-  sleipnir::VariableMatrix currentSum = 0.0;
+  sleipnir::Variable J = 0.0;
+  sleipnir::Variable currentSum = 0.0;
   for (size_t i = 0; i < currentTolerances.size(); ++i) {
     // The weight is 1/tolᵢ² where tolᵢ is the tolerance between the desired
     // and allocated current for subsystem i

--- a/examples/FlywheelDirectTranscription/src/Main.cpp
+++ b/examples/FlywheelDirectTranscription/src/Main.cpp
@@ -34,7 +34,7 @@ int main() {
 
   // Cost function - minimize error
   Eigen::Matrix<double, 1, 1> r{10.0};
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N + 1; ++k) {
     J += (r - X.Col(k)).T() * (r - X.Col(k));
   }

--- a/include/sleipnir/autodiff/VariableMatrix.hpp
+++ b/include/sleipnir/autodiff/VariableMatrix.hpp
@@ -543,6 +543,11 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
   friend SLEIPNIR_DLLEXPORT VariableMatrix operator-(const VariableMatrix& lhs);
 
   /**
+   * Implicit conversion operator from 1x1 VariableMatrix to Variable.
+   */
+  operator Variable() const;  // NOLINT
+
+  /**
    * Returns the transpose of the variable matrix.
    */
   VariableMatrix T() const;

--- a/include/sleipnir/optimization/OptimizationProblem.hpp
+++ b/include/sleipnir/optimization/OptimizationProblem.hpp
@@ -119,7 +119,7 @@ subject to cₑ(x) = 0
  * Next, we'll create a cost function for minimizing position error.
  * @code{.cpp}
  * // Cost function - minimize position error
- * sleipnir::VariableMatrix J = 0.0;
+ * sleipnir::Variable J = 0.0;
  * for (int k = 0; k < N + 1; ++k) {
  *   J += sleipnir::pow(10.0 - X(0, k), 2);
  * }
@@ -213,12 +213,17 @@ class SLEIPNIR_DLLEXPORT OptimizationProblem {
   OptimizationProblem() noexcept;
 
   /**
+   * Create a decision variable in the optimization problem.
+   */
+  [[nodiscard]] Variable DecisionVariable();
+
+  /**
    * Create a matrix of decision variables in the optimization problem.
    *
    * @param rows Number of matrix rows.
    * @param cols Number of matrix columns.
    */
-  [[nodiscard]] VariableMatrix DecisionVariable(int rows = 1, int cols = 1);
+  [[nodiscard]] VariableMatrix DecisionVariable(int rows, int cols = 1);
 
   /**
    * Tells the solver to minimize the output of the given cost function.
@@ -227,9 +232,9 @@ class SLEIPNIR_DLLEXPORT OptimizationProblem {
    * will find the closest solution to the initial conditions that's in the
    * feasible set.
    *
-   * @param cost The cost function to minimize. It must return a 1x1 matrix.
+   * @param cost The cost function to minimize.
    */
-  void Minimize(const VariableMatrix& cost);
+  void Minimize(const Variable& cost);
 
   /**
    * Tells the solver to minimize the output of the given cost function.
@@ -238,9 +243,9 @@ class SLEIPNIR_DLLEXPORT OptimizationProblem {
    * will find the closest solution to the initial conditions that's in the
    * feasible set.
    *
-   * @param cost The cost function to minimize. It must return a 1x1 matrix.
+   * @param cost The cost function to minimize.
    */
-  void Minimize(VariableMatrix&& cost);
+  void Minimize(Variable&& cost);
 
   /**
    * Tells the solver to maximize the output of the given objective function.
@@ -249,10 +254,9 @@ class SLEIPNIR_DLLEXPORT OptimizationProblem {
    * will find the closest solution to the initial conditions that's in the
    * feasible set.
    *
-   * @param objective The objective function to maximize. It must return a 1x1
-   *                  matrix.
+   * @param objective The objective function to maximize.
    */
-  void Maximize(const VariableMatrix& objective);
+  void Maximize(const Variable& objective);
 
   /**
    * Tells the solver to maximize the output of the given objective function.
@@ -261,10 +265,9 @@ class SLEIPNIR_DLLEXPORT OptimizationProblem {
    * will find the closest solution to the initial conditions that's in the
    * feasible set.
    *
-   * @param objective The objective function to maximize. It must return a 1x1
-   *                  matrix.
+   * @param objective The objective function to maximize.
    */
-  void Maximize(VariableMatrix&& objective);
+  void Maximize(Variable&& objective);
 
   /**
    * Tells the solver to solve the problem while satisfying the given equality

--- a/src/autodiff/VariableMatrix.cpp
+++ b/src/autodiff/VariableMatrix.cpp
@@ -321,6 +321,11 @@ VariableMatrix VariableMatrix::T() const {
   return result;
 }
 
+VariableMatrix::operator Variable() const {
+  assert(Rows() == 1 && Cols() == 1);
+  return (*this)(0, 0);
+}
+
 int VariableMatrix::Rows() const {
   return m_rows;
 }

--- a/src/optimization/OptimizationProblem.cpp
+++ b/src/optimization/OptimizationProblem.cpp
@@ -125,6 +125,11 @@ OptimizationProblem::OptimizationProblem() noexcept {
   m_inequalityConstraints.reserve(1024);
 }
 
+Variable OptimizationProblem::DecisionVariable() {
+  m_decisionVariables.emplace_back(0.0);
+  return m_decisionVariables.back();
+}
+
 VariableMatrix OptimizationProblem::DecisionVariable(int rows, int cols) {
   VariableMatrix vars{rows, cols};
   int oldSize = m_decisionVariables.size();
@@ -141,28 +146,22 @@ VariableMatrix OptimizationProblem::DecisionVariable(int rows, int cols) {
   return vars;
 }
 
-void OptimizationProblem::Minimize(const VariableMatrix& cost) {
-  assert(cost.Rows() == 1 && cost.Cols() == 1);
-  m_f = cost(0, 0);
+void OptimizationProblem::Minimize(const Variable& cost) {
+  m_f = cost;
 }
 
-void OptimizationProblem::Minimize(VariableMatrix&& cost) {
-  assert(cost.Rows() == 1 && cost.Cols() == 1);
-  m_f = std::move(cost(0, 0));
+void OptimizationProblem::Minimize(Variable&& cost) {
+  m_f = std::move(cost);
 }
 
-void OptimizationProblem::Maximize(const VariableMatrix& objective) {
-  assert(objective.Rows() == 1 && objective.Cols() == 1);
-
+void OptimizationProblem::Maximize(const Variable& objective) {
   // Maximizing an objective function is the same as minimizing its negative
-  m_f = -objective(0, 0);
+  m_f = -objective;
 }
 
-void OptimizationProblem::Maximize(VariableMatrix&& objective) {
-  assert(objective.Rows() == 1 && objective.Cols() == 1);
-
+void OptimizationProblem::Maximize(Variable&& objective) {
   // Maximizing an objective function is the same as minimizing its negative
-  m_f = -std::move(objective(0, 0));
+  m_f = -std::move(objective);
 }
 
 void OptimizationProblem::SubjectTo(EqualityConstraints&& constraint) {

--- a/test/src/autodiff/VariableMatrixTest.cpp
+++ b/test/src/autodiff/VariableMatrixTest.cpp
@@ -9,12 +9,12 @@ TEST(VariableMatrixTest, HessianSumOfSquares) {
   sleipnir::VectorXvar r{{25.0, 10.0, 5.0, 0.0}};
   sleipnir::VectorXvar x{{0.0, 0.0, 0.0, 0.0}};
 
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int i = 0; i < 4; ++i) {
     J += (r(i) - x(i)) * (r(i) - x(i));
   }
 
-  Eigen::MatrixXd H = sleipnir::Hessian{J(0, 0), x}.Calculate();
+  Eigen::MatrixXd H = sleipnir::Hessian{J, x}.Calculate();
   for (int row = 0; row < 4; ++row) {
     for (int col = 0; col < 4; ++col) {
       if (row == col) {

--- a/test/src/optimization/CartPoleProblemTest.cpp
+++ b/test/src/optimization/CartPoleProblemTest.cpp
@@ -237,7 +237,7 @@ TEST(CartPoleProblemTest, DirectTranscription) {
   }
 
   // Minimize sum squared inputs
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N; ++k) {
     J += U.Col(k).T() * U.Col(k);
   }

--- a/test/src/optimization/DecisionVariableTest.cpp
+++ b/test/src/optimization/DecisionVariableTest.cpp
@@ -9,13 +9,13 @@ TEST(DecisionVariableTest, ScalarInitAssign) {
 
   // Scalar zero init
   auto x = problem.DecisionVariable();
-  EXPECT_DOUBLE_EQ(0.0, x.Value(0));
+  EXPECT_DOUBLE_EQ(0.0, x.Value());
 
   // Scalar assignment
   x = 1.0;
-  EXPECT_DOUBLE_EQ(1.0, x.Value(0));
+  EXPECT_DOUBLE_EQ(1.0, x.Value());
   x = 2.0;
-  EXPECT_DOUBLE_EQ(2.0, x.Value(0));
+  EXPECT_DOUBLE_EQ(2.0, x.Value());
 }
 
 TEST(DecisionVariableTest, VectorInitAssign) {

--- a/test/src/optimization/DoubleIntegratorProblemTest.cpp
+++ b/test/src/optimization/DoubleIntegratorProblemTest.cpp
@@ -56,7 +56,7 @@ TEST(DoubleIntegratorProblemTest, MinimumTime) {
   problem.SubjectTo(U <= 1);
 
   // Cost function - minimize position error
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N + 1; ++k) {
     J += sleipnir::pow(r - X(0, k), 2);
   }

--- a/test/src/optimization/FlywheelProblemTest.cpp
+++ b/test/src/optimization/FlywheelProblemTest.cpp
@@ -50,7 +50,7 @@ TEST(FlywheelProblemTest, DirectTranscription) {
 
   // Cost function - minimize error
   Eigen::Matrix<double, 1, 1> r{10.0};
-  sleipnir::VariableMatrix J = 0.0;
+  sleipnir::Variable J = 0.0;
   for (int k = 0; k < N + 1; ++k) {
     J += (r - X.Col(k)).T() * (r - X.Col(k));
   }

--- a/test/src/optimization/LinearProblemTest.cpp
+++ b/test/src/optimization/LinearProblemTest.cpp
@@ -27,6 +27,6 @@ TEST(LinearProblemTest, Maximize) {
   EXPECT_EQ(sleipnir::ExpressionType::kLinear, status.inequalityConstraintType);
   EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-  EXPECT_NEAR(375.0, x.Value(0), 1e-6);
-  EXPECT_NEAR(250.0, y.Value(0), 1e-6);
+  EXPECT_NEAR(375.0, x.Value(), 1e-6);
+  EXPECT_NEAR(250.0, y.Value(), 1e-6);
 }

--- a/test/src/optimization/NonlinearProblemTest.cpp
+++ b/test/src/optimization/NonlinearProblemTest.cpp
@@ -34,7 +34,7 @@ TEST(NonlinearProblemTest, Quartic) {
   EXPECT_EQ(sleipnir::ExpressionType::kLinear, status.inequalityConstraintType);
   EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-  EXPECT_NEAR(1.0, x.Value(0), 1e-6);
+  EXPECT_NEAR(1.0, x.Value(), 1e-6);
 }
 
 TEST(NonlinearProblemTest, RosenbrockWithCubicAndLineConstraint) {
@@ -68,12 +68,12 @@ TEST(NonlinearProblemTest, RosenbrockWithCubicAndLineConstraint) {
 
       // Local minimum at (0.0, 0.0)
       // Global minimum at (1.0, 1.0)
-      EXPECT_TRUE(Near(0.0, x.Value(0), 1e-2) || Near(1.0, x.Value(0), 1e-2))
+      EXPECT_TRUE(Near(0.0, x.Value(), 1e-2) || Near(1.0, x.Value(), 1e-2))
           << fmt::format("  (x₀, y₀) = ({}, {})\n", x0, y0)
-          << fmt::format("  x.Value(0) = {}", x.Value(0));
-      EXPECT_TRUE(Near(0.0, y.Value(0), 1e-2) || Near(1.0, y.Value(0), 1e-2))
+          << fmt::format("  x.Value(0) = {}", x.Value());
+      EXPECT_TRUE(Near(0.0, y.Value(), 1e-2) || Near(1.0, y.Value(), 1e-2))
           << fmt::format("  (x₀, y₀) = ({}, {})\n", x0, y0)
-          << fmt::format("  y.Value(0) = {}", y.Value(0));
+          << fmt::format("  y.Value(0) = {}", y.Value());
     }
   }
 }
@@ -102,12 +102,12 @@ TEST(NonlinearProblemTest, RosenbrockWithDiskConstraint) {
                 status.inequalityConstraintType);
       EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-      EXPECT_NEAR(1.0, x.Value(0), 1e-1)
+      EXPECT_NEAR(1.0, x.Value(), 1e-1)
           << fmt::format("  (x₀, y₀) = ({}, {})\n", x0, y0)
-          << fmt::format("  x.Value(0) = {}", x.Value(0));
-      EXPECT_NEAR(1.0, y.Value(0), 1e-1)
+          << fmt::format("  x.Value(0) = {}", x.Value());
+      EXPECT_NEAR(1.0, y.Value(), 1e-1)
           << fmt::format("  (x₀, y₀) = ({}, {})\n", x0, y0)
-          << fmt::format("  x.Value(0) = {}", x.Value(0));
+          << fmt::format("  x.Value(0) = {}", x.Value());
     }
   }
 }

--- a/test/src/optimization/QuadraticProblemTest.cpp
+++ b/test/src/optimization/QuadraticProblemTest.cpp
@@ -18,7 +18,7 @@ TEST(QuadraticProblemTest, Unconstrained1d) {
   EXPECT_EQ(sleipnir::ExpressionType::kNone, status.inequalityConstraintType);
   EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-  EXPECT_NEAR(3.0, x.Value(0), 1e-6);
+  EXPECT_NEAR(3.0, x.Value(), 1e-6);
 }
 
 TEST(QuadraticProblemTest, Unconstrained2d) {
@@ -39,8 +39,8 @@ TEST(QuadraticProblemTest, Unconstrained2d) {
     EXPECT_EQ(sleipnir::ExpressionType::kNone, status.inequalityConstraintType);
     EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-    EXPECT_NEAR(0.0, x.Value(0), 1e-6);
-    EXPECT_NEAR(0.0, y.Value(0), 1e-6);
+    EXPECT_NEAR(0.0, x.Value(), 1e-6);
+    EXPECT_NEAR(0.0, y.Value(), 1e-6);
   }
 
   {
@@ -120,8 +120,8 @@ TEST(QuadraticProblemTest, EqualityConstrained) {
     EXPECT_EQ(sleipnir::ExpressionType::kNone, status.inequalityConstraintType);
     EXPECT_EQ(sleipnir::SolverExitCondition::kOk, status.exitCondition);
 
-    EXPECT_NEAR(18.0, x.Value(0), 1e-5);
-    EXPECT_NEAR(6.0, y.Value(0), 1e-5);
+    EXPECT_NEAR(18.0, x.Value(), 1e-5);
+    EXPECT_NEAR(6.0, y.Value(), 1e-5);
   }
 
   {


### PR DESCRIPTION
1. Add DecisionVariable() overload for scalars

This makes Value() work in cases like the following:
```cpp
auto x = problem.DecisionVariable();
x.Value();
```

2. Minimize() and Maximize() now take Variable instead of VariableMatrix

Cost and objective functions are inherently scalar, so this communicates intent better.

3. Add implicit conversion operator from 1x1 VariableMatrix to Variable

This makes assignments from VariableMatrix to Variable work, which can occur during cost function accumulation.
```cpp
sleipnir::Variable J = 0.0;
for (int k = 0; k < N + 1; ++k) {
  J += ((r - X.Col(k)).T() * (r - X.Col(k)));
}
```