### PR TITLE
Speed up Eigen Fortran compiler check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,9 @@ target_compile_definitions(Sleipnir PRIVATE SLEIPNIR_EXPORTS)
 
 include(FetchContent)
 
+# Disable Eigen's Fortran compiler check, which takes a long time in Windows CI
+set(CMAKE_Fortran_COMPILER "" CACHE STRING "" FORCE)
+
 # Eigen dependency
 FetchContent_Declare(
   Eigen3


### PR DESCRIPTION
We don't use Fortran, so the check isn't needed. This saves a lot of time in Windows CI jobs.