### PR TITLE
Move singleton initialization out of Zero()

### DIFF
--- a/include/sleipnir/autodiff/Expression.hpp
+++ b/include/sleipnir/autodiff/Expression.hpp
@@ -224,16 +224,6 @@ struct SLEIPNIR_DLLEXPORT Expression {
       const IntrusiveSharedPtr<Expression>& rhs);
 
   /**
-   * Expression-Expression compound addition operator.
-   *
-   * @param lhs Operator left-hand side.
-   * @param rhs Operator right-hand side.
-   */
-  friend SLEIPNIR_DLLEXPORT IntrusiveSharedPtr<Expression>& operator+=(
-      IntrusiveSharedPtr<Expression>& lhs,
-      const IntrusiveSharedPtr<Expression>& rhs);
-
-  /**
    * Expression-Expression subtraction operator.
    *
    * @param lhs Operator left-hand side.
@@ -318,6 +308,11 @@ static IntrusiveSharedPtr<Expression> MakeExpressionPtr(Args&&... args) {
   return AllocateIntrusiveShared<Expression>(GlobalPoolAllocator<Expression>(),
                                              std::forward<Args>(args)...);
 }
+
+/**
+ * Returns true if this expression is the constant zero.
+ */
+SLEIPNIR_DLLEXPORT bool IsZero(const IntrusiveSharedPtr<Expression>& ptr);
 
 /**
  * std::abs() for Expressions.
@@ -478,5 +473,18 @@ SLEIPNIR_DLLEXPORT IntrusiveSharedPtr<Expression> tanh(
     const IntrusiveSharedPtr<Expression>& x);
 
 }  // namespace detail
+
+// FIXME: Doxygen is confused:
+//
+//   Found ';' while parsing initializer list! (doxygen could be confused by a
+//   macro call without semicolon)
+
+//! @cond Doxygen_Suppress
+
+// Instantiate Expression pool in Expression.cpp instead to avoid ODR violation
+extern template EXPORT_TEMPLATE_DECLARE(SLEIPNIR_DLLEXPORT)
+    PoolAllocator<detail::Expression> GlobalPoolAllocator<detail::Expression>();
+
+//! @endcond
 
 }  // namespace sleipnir

--- a/src/autodiff/ExpressionGraph.cpp
+++ b/src/autodiff/ExpressionGraph.cpp
@@ -115,8 +115,10 @@ sleipnir::VectorXvar ExpressionGraph::GenerateGradientTree(
     auto& lhs = node->args[0];
     auto& rhs = node->args[1];
 
-    lhs->adjointExpr += node->gradientFuncs[0](lhs, rhs, node->adjointExpr);
-    rhs->adjointExpr += node->gradientFuncs[1](lhs, rhs, node->adjointExpr);
+    lhs->adjointExpr =
+        lhs->adjointExpr + node->gradientFuncs[0](lhs, rhs, node->adjointExpr);
+    rhs->adjointExpr =
+        rhs->adjointExpr + node->gradientFuncs[1](lhs, rhs, node->adjointExpr);
 
     // If variable is a leaf node, assign its adjoint to the gradient.
     if (node->row != -1) {

--- a/src/autodiff/Variable.cpp
+++ b/src/autodiff/Variable.cpp
@@ -32,10 +32,10 @@ Variable& Variable::operator=(int value) {
 }
 
 Variable& Variable::SetValue(double value) {
-  if (expr == detail::Zero()) {
+  if (detail::IsZero(expr)) {
     expr = detail::MakeExpressionPtr(value);
   } else {
-    if (expr->args[0] != detail::Zero()) {
+    if (!detail::IsZero(expr->args[0])) {
       fmt::print(stderr,
                  "WARNING: {}:{}: Modified the value of a dependent variable\n",
                  __FILE__, __LINE__);
@@ -46,10 +46,10 @@ Variable& Variable::SetValue(double value) {
 }
 
 Variable& Variable::SetValue(int value) {
-  if (expr == detail::Zero()) {
+  if (detail::IsZero(expr)) {
     expr = detail::MakeExpressionPtr(value);
   } else {
-    if (expr->args[0] != detail::Zero()) {
+    if (!detail::IsZero(expr->args[0])) {
       fmt::print(stderr,
                  "WARNING: {}:{}: Modified the value of a dependent variable\n",
                  __FILE__, __LINE__);
@@ -112,7 +112,7 @@ ExpressionType Variable::Type() const {
 }
 
 void Variable::Update() {
-  if (expr != detail::Zero()) {
+  if (!detail::IsZero(expr)) {
     detail::ExpressionGraph graph{*this};
     graph.Update();
   }


### PR DESCRIPTION
This avoids an atomic initialization check on every call to Zero(), so it's a bit faster.

This also exposed an ODR violation for the Expression Pool allocator, which has been fixed.