### PR TITLE
Make Expression(double, ExpressionType) use kConstant by default

### DIFF
--- a/include/sleipnir/autodiff/Expression.hpp
+++ b/include/sleipnir/autodiff/Expression.hpp
@@ -119,11 +119,11 @@ struct SLEIPNIR_DLLEXPORT Expression {
    * Constructs a nullary expression (an operator with no arguments).
    *
    * @param value The expression value.
-   * @param type The expression type. It should be either linear (the default)
-   *             or constant.
+   * @param type The expression type. It should be either constant (the default)
+   *             or linear.
    */
   explicit Expression(double value,
-                      ExpressionType type = ExpressionType::kLinear);
+                      ExpressionType type = ExpressionType::kConstant);
 
   /**
    * Constructs an unary expression (an operator with one argument).

--- a/include/sleipnir/autodiff/Variable.hpp
+++ b/include/sleipnir/autodiff/Variable.hpp
@@ -24,7 +24,7 @@ class SLEIPNIR_DLLEXPORT ExpressionGraph;
 class SLEIPNIR_DLLEXPORT Variable {
  public:
   /**
-   * Constructs a Variable initialized to zero.
+   * Constructs a linear Variable with a value of zero.
    */
   Variable() = default;
 
@@ -47,7 +47,14 @@ class SLEIPNIR_DLLEXPORT Variable {
    *
    * @param expr The autodiff variable.
    */
-  explicit Variable(detail::ExpressionPtr expr);
+  explicit Variable(const detail::ExpressionPtr& expr);
+
+  /**
+   * Constructs a Variable pointing to the specified expression.
+   *
+   * @param expr The autodiff variable.
+   */
+  explicit Variable(detail::ExpressionPtr&& expr);
 
   /**
    * Assignment operator for double.
@@ -174,7 +181,8 @@ class SLEIPNIR_DLLEXPORT Variable {
 
  private:
   /// The expression node.
-  detail::ExpressionPtr expr = detail::Zero();
+  detail::ExpressionPtr expr =
+      detail::MakeExpressionPtr(0.0, ExpressionType::kLinear);
 
   friend SLEIPNIR_DLLEXPORT Variable abs(const Variable& x);
   friend SLEIPNIR_DLLEXPORT Variable acos(const Variable& x);

--- a/src/autodiff/Expression.cpp
+++ b/src/autodiff/Expression.cpp
@@ -246,7 +246,7 @@ ExpressionPtr abs(  // NOLINT
 ExpressionPtr acos(  // NOLINT
     const ExpressionPtr& x) {
   if (IsZero(x)) {
-    return MakeExpressionPtr(std::numbers::pi / 2.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(std::numbers::pi / 2.0);
   }
 
   // Evaluate the expression's type
@@ -265,8 +265,7 @@ ExpressionPtr acos(  // NOLINT
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
         return -parentAdjoint /
-               sleipnir::detail::sqrt(
-                   MakeExpressionPtr(1.0, ExpressionType::kConstant) - x * x);
+               sleipnir::detail::sqrt(MakeExpressionPtr(1.0) - x * x);
       },
       x);
 }
@@ -293,8 +292,7 @@ ExpressionPtr asin(  // NOLINT
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
         return parentAdjoint /
-               sleipnir::detail::sqrt(
-                   MakeExpressionPtr(1.0, ExpressionType::kConstant) - x * x);
+               sleipnir::detail::sqrt(MakeExpressionPtr(1.0) - x * x);
       },
       x);
 }
@@ -320,8 +318,7 @@ ExpressionPtr atan(  // NOLINT
       },
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
-        return parentAdjoint /
-               (MakeExpressionPtr(1.0, ExpressionType::kConstant) + x * x);
+        return parentAdjoint / (MakeExpressionPtr(1.0) + x * x);
       },
       x);
 }
@@ -331,7 +328,7 @@ ExpressionPtr atan2(  // NOLINT
   if (IsZero(y)) {
     return Zero();
   } else if (IsZero(x)) {
-    return MakeExpressionPtr(std::numbers::pi / 2.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(std::numbers::pi / 2.0);
   }
 
   // Evaluate the expression's type
@@ -365,7 +362,7 @@ ExpressionPtr atan2(  // NOLINT
 ExpressionPtr cos(  // NOLINT
     const ExpressionPtr& x) {
   if (IsZero(x)) {
-    return MakeExpressionPtr(1.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(1.0);
   }
 
   // Evaluate the expression's type
@@ -391,7 +388,7 @@ ExpressionPtr cos(  // NOLINT
 ExpressionPtr cosh(  // NOLINT
     const ExpressionPtr& x) {
   if (IsZero(x)) {
-    return MakeExpressionPtr(1.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(1.0);
   }
 
   // Evaluate the expression's type
@@ -437,8 +434,7 @@ ExpressionPtr erf(  // NOLINT
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
         return parentAdjoint *
-               MakeExpressionPtr(2.0 * std::numbers::inv_sqrtpi,
-                                 ExpressionType::kConstant) *
+               MakeExpressionPtr(2.0 * std::numbers::inv_sqrtpi) *
                sleipnir::detail::exp(-x * x);
       },
       x);
@@ -447,7 +443,7 @@ ExpressionPtr erf(  // NOLINT
 ExpressionPtr exp(  // NOLINT
     const ExpressionPtr& x) {
   if (IsZero(x)) {
-    return MakeExpressionPtr(1.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(1.0);
   }
 
   // Evaluate the expression's type
@@ -501,7 +497,7 @@ ExpressionPtr hypot(  // NOLINT
            const ExpressionPtr& parentAdjoint) {
           return parentAdjoint * y / sleipnir::detail::hypot(x, y);
         },
-        MakeExpressionPtr(0.0, ExpressionType::kConstant), y);
+        MakeExpressionPtr(0.0), y);
   } else if (!IsZero(x) && IsZero(y)) {
     // Evaluate the expression's type
     ExpressionType type;
@@ -527,7 +523,7 @@ ExpressionPtr hypot(  // NOLINT
            const ExpressionPtr& parentAdjoint) {
           return parentAdjoint * y / sleipnir::detail::hypot(x, y);
         },
-        x, MakeExpressionPtr(0.0, ExpressionType::kConstant));
+        x, MakeExpressionPtr(0.0));
   } else {
     // Evaluate the expression's type
     ExpressionType type;
@@ -601,9 +597,7 @@ ExpressionPtr log10(  // NOLINT
       },
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
-        return parentAdjoint / (MakeExpressionPtr(std::numbers::ln10,
-                                                  ExpressionType::kConstant) *
-                                x);
+        return parentAdjoint / (MakeExpressionPtr(std::numbers::ln10) * x);
       },
       x);
 }
@@ -614,7 +608,7 @@ ExpressionPtr pow(  // NOLINT
     return Zero();
   }
   if (IsZero(power)) {
-    return MakeExpressionPtr(1.0, ExpressionType::kConstant);
+    return MakeExpressionPtr(1.0);
   }
 
   // Evaluate the expression's type
@@ -654,9 +648,7 @@ ExpressionPtr pow(  // NOLINT
       [](const ExpressionPtr& base, const ExpressionPtr& power,
          const ExpressionPtr& parentAdjoint) {
         return parentAdjoint *
-               sleipnir::detail::pow(
-                   base,
-                   power - MakeExpressionPtr(1, ExpressionType::kConstant)) *
+               sleipnir::detail::pow(base, power - MakeExpressionPtr(1)) *
                power;
       },
       [](const ExpressionPtr& base, const ExpressionPtr& power,
@@ -666,9 +658,7 @@ ExpressionPtr pow(  // NOLINT
           return Zero();
         } else {
           return parentAdjoint *
-                 sleipnir::detail::pow(
-                     base,
-                     power - MakeExpressionPtr(1, ExpressionType::kConstant)) *
+                 sleipnir::detail::pow(base, power - MakeExpressionPtr(1)) *
                  base * sleipnir::detail::log(base);
         }
       },
@@ -778,8 +768,7 @@ ExpressionPtr sqrt(  // NOLINT
       [](const ExpressionPtr& x, const ExpressionPtr&,
          const ExpressionPtr& parentAdjoint) {
         return parentAdjoint /
-               (MakeExpressionPtr(2.0, ExpressionType::kConstant) *
-                sleipnir::detail::sqrt(x));
+               (MakeExpressionPtr(2.0) * sleipnir::detail::sqrt(x));
       },
       x);
 }

--- a/src/autodiff/ExpressionGraph.cpp
+++ b/src/autodiff/ExpressionGraph.cpp
@@ -99,8 +99,7 @@ sleipnir::VectorXvar ExpressionGraph::GenerateGradientTree(
 
   // Zero adjoints. The root node's adjoint is 1.0 as df/df is always 1.
   if (m_adjointList.size() > 0) {
-    m_adjointList[0]->adjointExpr =
-        MakeExpressionPtr(1.0, ExpressionType::kConstant);
+    m_adjointList[0]->adjointExpr = MakeExpressionPtr(1.0);
     for (auto it = m_adjointList.begin() + 1; it != m_adjointList.end(); ++it) {
       auto& node = *it;
       node->adjointExpr = Zero();

--- a/src/autodiff/Variable.cpp
+++ b/src/autodiff/Variable.cpp
@@ -9,22 +9,22 @@
 
 namespace sleipnir {
 
-Variable::Variable(double value)
-    : expr{detail::MakeExpressionPtr(value, ExpressionType::kConstant)} {}
+Variable::Variable(double value) : expr{detail::MakeExpressionPtr(value)} {}
 
-Variable::Variable(int value)
-    : expr{detail::MakeExpressionPtr(value, ExpressionType::kConstant)} {}
+Variable::Variable(int value) : expr{detail::MakeExpressionPtr(value)} {}
 
-Variable::Variable(detail::ExpressionPtr expr) : expr{std::move(expr)} {}
+Variable::Variable(const detail::ExpressionPtr& expr) : expr{expr} {}
+
+Variable::Variable(detail::ExpressionPtr&& expr) : expr{std::move(expr)} {}
 
 Variable& Variable::operator=(double value) {
-  expr = detail::MakeExpressionPtr(value, ExpressionType::kConstant);
+  expr = detail::MakeExpressionPtr(value);
 
   return *this;
 }
 
 Variable& Variable::operator=(int value) {
-  expr = detail::MakeExpressionPtr(value, ExpressionType::kConstant);
+  expr = detail::MakeExpressionPtr(value);
 
   return *this;
 }

--- a/src/autodiff/VariableMatrix.cpp
+++ b/src/autodiff/VariableMatrix.cpp
@@ -16,13 +16,11 @@ VariableMatrix::VariableMatrix(int rows, int cols)
 }
 
 VariableMatrix::VariableMatrix(double value) : m_rows{1}, m_cols{1} {
-  m_storage.emplace_back(
-      detail::MakeExpressionPtr(value, ExpressionType::kConstant));
+  m_storage.emplace_back(detail::MakeExpressionPtr(value));
 }
 
 VariableMatrix::VariableMatrix(int value) : m_rows{1}, m_cols{1} {
-  m_storage.emplace_back(
-      detail::MakeExpressionPtr(value, ExpressionType::kConstant));
+  m_storage.emplace_back(detail::MakeExpressionPtr(value));
 }
 
 VariableMatrix& VariableMatrix::operator=(double value) {

--- a/test/src/autodiff/VariableTest.cpp
+++ b/test/src/autodiff/VariableTest.cpp
@@ -7,5 +7,5 @@ TEST(VariableTest, DefaultConstructor) {
   sleipnir::Variable a;
 
   EXPECT_EQ(0.0, a.Value());
-  EXPECT_EQ(sleipnir::ExpressionType::kConstant, a.Type());
+  EXPECT_EQ(sleipnir::ExpressionType::kLinear, a.Type());
 }

--- a/test/src/control/OCPSolverTest_Flywheel.cpp
+++ b/test/src/control/OCPSolverTest_Flywheel.cpp
@@ -69,14 +69,7 @@ void TestFlywheel(std::string testName, Eigen::Matrix<double, 1, 1> A,
       solver.Solve({.diagnostics = CmdlineArgPresent(kEnableDiagnostics)});
 
   EXPECT_EQ(sleipnir::ExpressionType::kQuadratic, status.costFunctionType);
-  if (method == sleipnir::TranscriptionMethod::kSingleShooting) {
-    // The initial state isn't dependent on any decision variables, so
-    // constraining it to a constant makes the constraint itself constant
-    EXPECT_EQ(sleipnir::ExpressionType::kConstant,
-              status.equalityConstraintType);
-  } else {
-    EXPECT_EQ(sleipnir::ExpressionType::kLinear, status.equalityConstraintType);
-  }
+  EXPECT_EQ(sleipnir::ExpressionType::kLinear, status.equalityConstraintType);
   EXPECT_EQ(sleipnir::ExpressionType::kLinear, status.inequalityConstraintType);
   EXPECT_EQ(sleipnir::SolverExitCondition::kSuccess, status.exitCondition);
 


### PR DESCRIPTION
Also add Variable(ExpressionPtr&&) to avoid refcount churn.