### PR TITLE
Fix potential std::vector out-of-bounds access

### DIFF
--- a/include/sleipnir/autodiff/VariableMatrix.hpp
+++ b/include/sleipnir/autodiff/VariableMatrix.hpp
@@ -163,7 +163,7 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
    *
    * @param values Variable array to wrap.
    */
-  explicit VariableMatrix(std::span<Variable> values);
+  explicit VariableMatrix(std::span<const Variable> values);
 
   /**
    * Constructs a matrix wrapper around a Variable array.
@@ -172,7 +172,7 @@ class SLEIPNIR_DLLEXPORT VariableMatrix {
    * @param rows The number of matrix rows.
    * @param cols The number of matrix columns.
    */
-  VariableMatrix(std::span<Variable> values, int rows, int cols);
+  VariableMatrix(std::span<const Variable> values, int rows, int cols);
 
   /**
    * Returns a block pointing to the given row and column.

--- a/src/autodiff/VariableMatrix.cpp
+++ b/src/autodiff/VariableMatrix.cpp
@@ -108,7 +108,7 @@ VariableMatrix::VariableMatrix(
   }
 }
 
-VariableMatrix::VariableMatrix(std::span<Variable> values)
+VariableMatrix::VariableMatrix(std::span<const Variable> values)
     : m_rows{static_cast<int>(values.size())}, m_cols{1} {
   for (int row = 0; row < Rows(); ++row) {
     for (int col = 0; col < Cols(); ++col) {
@@ -117,7 +117,8 @@ VariableMatrix::VariableMatrix(std::span<Variable> values)
   }
 }
 
-VariableMatrix::VariableMatrix(std::span<Variable> values, int rows, int cols)
+VariableMatrix::VariableMatrix(std::span<const Variable> values, int rows,
+                               int cols)
     : m_rows{rows}, m_cols{cols} {
   assert(static_cast<int>(values.size()) == Rows() * Cols());
   for (int row = 0; row < Rows(); ++row) {

--- a/src/optimization/solver/util/FeasibilityRestoration.hpp
+++ b/src/optimization/solver/util/FeasibilityRestoration.hpp
@@ -82,34 +82,35 @@ inline void FeasibilityRestoration(
     fr_decisionVariables.emplace_back();
   }
 
-  VariableMatrix xAD{{&fr_decisionVariables[0], decisionVariables.size()}};
+  auto it = fr_decisionVariables.cbegin();
 
-  VariableMatrix p_e{{&fr_decisionVariables[decisionVariables.size()],
-                      equalityConstraints.size()}};
-  VariableMatrix n_e{{&fr_decisionVariables[decisionVariables.size() +
-                                            equalityConstraints.size()],
-                      equalityConstraints.size()}};
-  VariableMatrix p_i{{&fr_decisionVariables[decisionVariables.size() +
-                                            2 * equalityConstraints.size()],
-                      inequalityConstraints.size()}};
-  VariableMatrix n_i{{&fr_decisionVariables[decisionVariables.size() +
-                                            2 * equalityConstraints.size() +
-                                            inequalityConstraints.size()],
-                      inequalityConstraints.size()}};
+  VariableMatrix xAD{std::span{it, it + decisionVariables.size()}};
+  it += decisionVariables.size();
+
+  VariableMatrix p_e{std::span{it, it + equalityConstraints.size()}};
+  it += equalityConstraints.size();
+
+  VariableMatrix n_e{std::span{it, it + equalityConstraints.size()}};
+  it += equalityConstraints.size();
+
+  VariableMatrix p_i{std::span{it, it + inequalityConstraints.size()}};
+  it += inequalityConstraints.size();
+
+  VariableMatrix n_i{std::span{it, it + inequalityConstraints.size()}};
 
   // Set initial values for pₑ, nₑ, pᵢ, and nᵢ.
   //
   //
   // From equation (33) of [2]:
-  //                      ______________________
-  //       μ − ρ c(x) +  /(μ − ρ c(x))²   μ c(x)
-  //   n = −−−−−−−−−−   / (−−−−−−−−−−)  + −−−−−−     (1)
-  //           2ρ      √  (    2ρ    )      2ρ
+  //                       ______________________
+  //       μ − ρ c(x)     /(μ − ρ c(x))²   μ c(x)
+  //   n = −−−−−−−−−− +  / (−−−−−−−−−−)  + −−−−−−     (1)
+  //           2ρ       √  (    2ρ    )      2ρ
   //
   // The quadratic formula:
   //             ________
   //       -b + √b² - 4ac
-  //   x = −−−−−−−−−−−−−−                            (2)
+  //   x = −−−−−−−−−−−−−−                             (2)
   //             2a
   //
   // Rearrange (1) to fit the quadratic formula better:


### PR DESCRIPTION
If the vector is empty, or the offset into the vector equals the size, `operator[]` in `&vector[offset]` will attempt to access a nonexistent element. This is undefined behavior that GCC catches with an assertion.