### PR TITLE
Remove explicit LTO setting

### DIFF
--- a/cmake/modules/SleipnirCompilerFlags.cmake
+++ b/cmake/modules/SleipnirCompilerFlags.cmake
@@ -16,6 +16,20 @@ macro(sleipnir_compiler_flags target)
             )
         endif()
 
+        # Disable warning false positives in Eigen
+        if(
+            ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
+            AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11"
+        )
+            target_compile_options(${target} PRIVATE -Wno-maybe-uninitialized)
+        endif()
+        if(
+            ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
+            AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "12"
+        )
+            target_compile_options(${target} PRIVATE -Wno-array-bounds)
+        endif()
+
         # Disable warning false positives in fmt
         if(
             ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"
@@ -37,6 +51,4 @@ macro(sleipnir_compiler_flags target)
     if(MSVC)
         target_compile_options(${target} PUBLIC /utf-8 /bigobj)
     endif()
-
-    set_property(TARGET ${target} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 endmacro()


### PR DESCRIPTION
Some compilers don't support it, so it's better for the user to enable it via CMAKE_INTERPROCEDURAL_OPTIMIZATION.