### PR TITLE
Make Expression construction constexpr

### DIFF
--- a/benchmarks/scalability/Util.hpp
+++ b/benchmarks/scalability/Util.hpp
@@ -19,7 +19,8 @@
  * decimals.
  */
 template <typename Rep, typename Period = std::ratio<1>>
-double ToMilliseconds(const std::chrono::duration<Rep, Period>& duration) {
+constexpr double ToMilliseconds(
+    const std::chrono::duration<Rep, Period>& duration) {
   using std::chrono::duration_cast;
   using std::chrono::nanoseconds;
   return duration_cast<nanoseconds>(duration).count() / 1e6;

--- a/include/sleipnir/autodiff/Variable.hpp
+++ b/include/sleipnir/autodiff/Variable.hpp
@@ -86,7 +86,7 @@ class SLEIPNIR_DLLEXPORT Variable {
     } else {
       // We only need to check the first argument since unary and binary
       // operators both use it
-      if (!expr->args[0]->IsConstant(0.0)) {
+      if (expr->args[0] != nullptr && !expr->args[0]->IsConstant(0.0)) {
         sleipnir::println(
             stderr,
             "WARNING: {}:{}: Modified the value of a dependent variable",
@@ -108,7 +108,7 @@ class SLEIPNIR_DLLEXPORT Variable {
     } else {
       // We only need to check the first argument since unary and binary
       // operators both use it
-      if (!expr->args[0]->IsConstant(0.0)) {
+      if (expr->args[0] != nullptr && !expr->args[0]->IsConstant(0.0)) {
         sleipnir::println(
             stderr,
             "WARNING: {}:{}: Modified the value of a dependent variable",

--- a/include/sleipnir/util/IntrusiveSharedPtr.hpp
+++ b/include/sleipnir/util/IntrusiveSharedPtr.hpp
@@ -41,13 +41,13 @@ class IntrusiveSharedPtr {
    * Constructs an intrusive shared pointer from the given pointer and takes
    * ownership.
    */
-  explicit IntrusiveSharedPtr(T* ptr) noexcept : m_ptr{ptr} {
+  explicit constexpr IntrusiveSharedPtr(T* ptr) noexcept : m_ptr{ptr} {
     if (m_ptr != nullptr) {
       IntrusiveSharedPtrIncRefCount(m_ptr);
     }
   }
 
-  ~IntrusiveSharedPtr() {
+  constexpr ~IntrusiveSharedPtr() {
     if (m_ptr != nullptr) {
       IntrusiveSharedPtrDecRefCount(m_ptr);
     }
@@ -56,7 +56,7 @@ class IntrusiveSharedPtr {
   /**
    * Copy constructs from the given intrusive shared pointer.
    */
-  IntrusiveSharedPtr(const IntrusiveSharedPtr<T>& rhs) noexcept
+  constexpr IntrusiveSharedPtr(const IntrusiveSharedPtr<T>& rhs) noexcept
       : m_ptr{rhs.m_ptr} {
     if (m_ptr != nullptr) {
       IntrusiveSharedPtrIncRefCount(m_ptr);
@@ -66,7 +66,7 @@ class IntrusiveSharedPtr {
   /**
    * Makes a copy of the given intrusive shared pointer.
    */
-  IntrusiveSharedPtr<T>& operator=(  // NOLINT
+  constexpr IntrusiveSharedPtr<T>& operator=(  // NOLINT
       const IntrusiveSharedPtr<T>& rhs) noexcept {
     if (m_ptr == rhs.m_ptr) {
       return *this;
@@ -88,13 +88,14 @@ class IntrusiveSharedPtr {
   /**
    * Move constructs from the given intrusive shared pointer.
    */
-  IntrusiveSharedPtr(IntrusiveSharedPtr<T>&& rhs) noexcept
+  constexpr IntrusiveSharedPtr(IntrusiveSharedPtr<T>&& rhs) noexcept
       : m_ptr{std::exchange(rhs.m_ptr, nullptr)} {}
 
   /**
    * Move assigns from the given intrusive shared pointer.
    */
-  IntrusiveSharedPtr<T>& operator=(IntrusiveSharedPtr<T>&& rhs) noexcept {
+  constexpr IntrusiveSharedPtr<T>& operator=(
+      IntrusiveSharedPtr<T>&& rhs) noexcept {
     if (m_ptr == rhs.m_ptr) {
       return *this;
     }
@@ -107,29 +108,29 @@ class IntrusiveSharedPtr {
   /**
    * Returns the internal pointer.
    */
-  T* Get() const noexcept { return m_ptr; }
+  constexpr T* Get() const noexcept { return m_ptr; }
 
   /**
    * Returns the object pointed to by the internal pointer.
    */
-  T& operator*() const noexcept { return *m_ptr; }
+  constexpr T& operator*() const noexcept { return *m_ptr; }
 
   /**
    * Returns the internal pointer.
    */
-  T* operator->() const noexcept { return m_ptr; }
+  constexpr T* operator->() const noexcept { return m_ptr; }
 
   /**
    * Returns true if the internal pointer isn't nullptr.
    */
-  explicit operator bool() const noexcept { return m_ptr != nullptr; }
+  explicit constexpr operator bool() const noexcept { return m_ptr != nullptr; }
 
   /**
    * Returns true if the given intrusive shared pointers point to the same
    * object.
    */
-  friend bool operator==(const IntrusiveSharedPtr<T>& lhs,
-                         const IntrusiveSharedPtr<T>& rhs) noexcept {
+  friend constexpr bool operator==(const IntrusiveSharedPtr<T>& lhs,
+                                   const IntrusiveSharedPtr<T>& rhs) noexcept {
     return lhs.m_ptr == rhs.m_ptr;
   }
 
@@ -137,24 +138,24 @@ class IntrusiveSharedPtr {
    * Returns true if the given intrusive shared pointers point to different
    * objects.
    */
-  friend bool operator!=(const IntrusiveSharedPtr<T>& lhs,
-                         const IntrusiveSharedPtr<T>& rhs) noexcept {
+  friend constexpr bool operator!=(const IntrusiveSharedPtr<T>& lhs,
+                                   const IntrusiveSharedPtr<T>& rhs) noexcept {
     return lhs.m_ptr != rhs.m_ptr;
   }
 
   /**
    * Returns true if the left-hand intrusive shared pointer points to nullptr.
    */
-  friend bool operator==(const IntrusiveSharedPtr<T>& lhs,
-                         std::nullptr_t) noexcept {
+  friend constexpr bool operator==(const IntrusiveSharedPtr<T>& lhs,
+                                   std::nullptr_t) noexcept {
     return lhs.m_ptr == nullptr;
   }
 
   /**
    * Returns true if the right-hand intrusive shared pointer points to nullptr.
    */
-  friend bool operator==(std::nullptr_t,
-                         const IntrusiveSharedPtr<T>& rhs) noexcept {
+  friend constexpr bool operator==(std::nullptr_t,
+                                   const IntrusiveSharedPtr<T>& rhs) noexcept {
     return nullptr == rhs.m_ptr;
   }
 
@@ -162,8 +163,8 @@ class IntrusiveSharedPtr {
    * Returns true if the left-hand intrusive shared pointer doesn't point to
    * nullptr.
    */
-  friend bool operator!=(const IntrusiveSharedPtr<T>& lhs,
-                         std::nullptr_t) noexcept {
+  friend constexpr bool operator!=(const IntrusiveSharedPtr<T>& lhs,
+                                   std::nullptr_t) noexcept {
     return lhs.m_ptr != nullptr;
   }
 
@@ -171,8 +172,8 @@ class IntrusiveSharedPtr {
    * Returns true if the right-hand intrusive shared pointer doesn't point to
    * nullptr.
    */
-  friend bool operator!=(std::nullptr_t,
-                         const IntrusiveSharedPtr<T>& rhs) noexcept {
+  friend constexpr bool operator!=(std::nullptr_t,
+                                   const IntrusiveSharedPtr<T>& rhs) noexcept {
     return nullptr != rhs.m_ptr;
   }
 

--- a/include/sleipnir/util/Pool.hpp
+++ b/include/sleipnir/util/Pool.hpp
@@ -26,12 +26,12 @@ class PoolResource {
   /**
    * Constructs a pool resource with one chunk allocated.
    */
-  PoolResource() { AddChunk(); }
+  constexpr PoolResource() { AddChunk(); }
 
-  PoolResource(const PoolResource&) = delete;
-  PoolResource& operator=(const PoolResource&) = delete;
-  PoolResource(PoolResource&&) = default;
-  PoolResource& operator=(PoolResource&&) = default;
+  constexpr PoolResource(const PoolResource&) = delete;
+  constexpr PoolResource& operator=(const PoolResource&) = delete;
+  constexpr PoolResource(PoolResource&&) = default;
+  constexpr PoolResource& operator=(PoolResource&&) = default;
 
   /**
    * Returns a block of memory from the pool.
@@ -40,7 +40,8 @@ class PoolResource {
    * @param alignment Alignment of the block (unused).
    */
   [[nodiscard]]
-  void* allocate(size_t bytes, size_t alignment = alignof(std::max_align_t)) {
+  constexpr void* allocate(size_t bytes,
+                           size_t alignment = alignof(std::max_align_t)) {
     if (m_freeList.empty()) {
       AddChunk();
     }
@@ -57,15 +58,16 @@ class PoolResource {
    * @param bytes Number of bytes in the block (unused).
    * @param alignment Alignment of the block (unused).
    */
-  void deallocate(void* p, size_t bytes,
-                  size_t alignment = alignof(std::max_align_t)) {
+  constexpr void deallocate(void* p, size_t bytes,
+                            size_t alignment = alignof(std::max_align_t)) {
     m_freeList.emplace_back(static_cast<T*>(p));
   }
 
   /**
    * Returns true if this pool resource has the same backing storage as another.
    */
-  bool is_equal(const PoolResource<T, BlocksPerChunk>& other) const noexcept {
+  constexpr bool is_equal(
+      const PoolResource<T, BlocksPerChunk>& other) const noexcept {
     return this == &other;
   }
 
@@ -79,7 +81,7 @@ class PoolResource {
    * Adds a memory chunk to the pool, partitions it into blocks of size
    * sizeof(T), and appends pointers to them to the free list.
    */
-  void AddChunk() {
+  constexpr void AddChunk() {
     m_buffer.emplace_back(new uint8_t[kBlockSize * BlocksPerChunk]);
     for (int i = BlocksPerChunk - 1; i >= 0; --i) {
       m_freeList.emplace_back(reinterpret_cast<T*>(m_buffer.back().get()) + i);
@@ -106,15 +108,17 @@ class PoolAllocator {
    *
    * @param r The pool resource.
    */
-  explicit PoolAllocator(PoolResource<T, BlocksPerChunk>* r)
+  explicit constexpr PoolAllocator(PoolResource<T, BlocksPerChunk>* r)
       : m_memoryResource{r} {}
 
   /**
    * Copy constructor.
    */
-  PoolAllocator(const PoolAllocator<T, BlocksPerChunk>& other) = default;
+  constexpr PoolAllocator(const PoolAllocator<T, BlocksPerChunk>& other) =
+      default;
 
-  PoolAllocator<T>& operator=(const PoolAllocator<T, BlocksPerChunk>&) = delete;
+  constexpr PoolAllocator<T>& operator=(
+      const PoolAllocator<T, BlocksPerChunk>&) = delete;
 
   /**
    * Returns a block of memory from the pool.
@@ -122,7 +126,7 @@ class PoolAllocator {
    * @param n Number of bytes in the block (unused).
    */
   [[nodiscard]]
-  T* allocate(size_t n) {
+  constexpr T* allocate(size_t n) {
     return static_cast<T*>(m_memoryResource->allocate(n));
   }
 
@@ -132,7 +136,9 @@ class PoolAllocator {
    * @param p A pointer to the block of memory.
    * @param n Number of bytes in the block (unused).
    */
-  void deallocate(T* p, size_t n) { m_memoryResource->deallocate(p, n); }
+  constexpr void deallocate(T* p, size_t n) {
+    m_memoryResource->deallocate(p, n);
+  }
 
  private:
   PoolResource<T, BlocksPerChunk>* m_memoryResource;

--- a/jormungandr/cpp/Docstrings.hpp
+++ b/jormungandr/cpp/Docstrings.hpp
@@ -1843,7 +1843,19 @@ R"doc(Refcount decrement for intrusive shared pointer.
 Parameter ``expr``:
     The shared pointer's managed object.)doc";
 
+static const char *__doc_sleipnir_detail_IntrusiveSharedPtrDecRefCount_2 =
+R"doc(Refcount decrement for intrusive shared pointer.
+
+Parameter ``expr``:
+    The shared pointer's managed object.)doc";
+
 static const char *__doc_sleipnir_detail_IntrusiveSharedPtrIncRefCount =
+R"doc(Refcount increment for intrusive shared pointer.
+
+Parameter ``expr``:
+    The shared pointer's managed object.)doc";
+
+static const char *__doc_sleipnir_detail_IntrusiveSharedPtrIncRefCount_2 =
 R"doc(Refcount increment for intrusive shared pointer.
 
 Parameter ``expr``:


### PR DESCRIPTION
Components Expression uses were also made constexpr. Anything that uses dynamic memory allocation still isn't constexpr, like ExpressionPtr creation.