### PR TITLE
Templatize formatters

### DIFF
--- a/include/sleipnir/util/Formatters.hpp
+++ b/include/sleipnir/util/Formatters.hpp
@@ -27,11 +27,13 @@ template <typename Derived, typename CharT>
   requires std::derived_from<Derived, Eigen::DenseBase<Derived>> ||
            std::derived_from<Derived, Eigen::SparseCompressedBase<Derived>>
 struct fmt::formatter<Derived, CharT> {
-  constexpr auto parse(fmt::format_parse_context& ctx) {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
     return m_underlying.parse(ctx);
   }
 
-  auto format(const Derived& mat, fmt::format_context& ctx) const {
+  template <typename FmtContext>
+  auto format(const Derived& mat, FmtContext& ctx) const {
     auto out = ctx.out();
 
     for (int row = 0; row < mat.rows(); ++row) {
@@ -57,12 +59,13 @@ struct fmt::formatter<Derived, CharT> {
  */
 template <>
 struct fmt::formatter<sleipnir::Variable> {
-  constexpr auto parse(fmt::format_parse_context& ctx) {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
     return m_underlying.parse(ctx);
   }
 
-  auto format(const sleipnir::Variable& variable,
-              fmt::format_context& ctx) const {
+  template <typename FmtContext>
+  auto format(const sleipnir::Variable& variable, FmtContext& ctx) const {
     return m_underlying.format(variable.Value(), ctx);
   }
 
@@ -77,11 +80,13 @@ template <typename T>
   requires std::same_as<T, sleipnir::VariableBlock<sleipnir::VariableMatrix>> ||
            std::same_as<T, sleipnir::VariableMatrix>
 struct fmt::formatter<T> {
-  constexpr auto parse(fmt::format_parse_context& ctx) {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
     return m_underlying.parse(ctx);
   }
 
-  auto format(const T& mat, fmt::format_context& ctx) const {
+  template <typename FmtContext>
+  auto format(const T& mat, FmtContext& ctx) const {
     auto out = ctx.out();
 
     for (int row = 0; row < mat.Rows(); ++row) {


### PR DESCRIPTION
This is required for compatibility with libc++'s std::format.