### PR TITLE
Add back OptimizationProblem default noexcept constructor

### DIFF
--- a/include/sleipnir/optimization/OptimizationProblem.hpp
+++ b/include/sleipnir/optimization/OptimizationProblem.hpp
@@ -51,6 +51,11 @@ subject to cₑ(x) = 0
 class SLEIPNIR_DLLEXPORT OptimizationProblem {
  public:
   /**
+   * Construct the optimization problem.
+   */
+  OptimizationProblem() noexcept = default;
+
+  /**
    * Create a decision variable in the optimization problem.
    */
   [[nodiscard]]

--- a/jormungandr/cpp/Docstrings.hpp
+++ b/jormungandr/cpp/Docstrings.hpp
@@ -582,6 +582,8 @@ in the feasible set.
 Parameter ``cost``:
     The cost function to minimize.)doc";
 
+static const char *__doc_sleipnir_OptimizationProblem_OptimizationProblem = R"doc(Construct the optimization problem.)doc";
+
 static const char *__doc_sleipnir_OptimizationProblem_Solve =
 R"doc(Solve the optimization problem. The solution will be stored in the
 original variables used to construct the problem.

--- a/jormungandr/cpp/optimization/BindOptimizationProblem.cpp
+++ b/jormungandr/cpp/optimization/BindOptimizationProblem.cpp
@@ -17,7 +17,8 @@ namespace sleipnir {
 void BindOptimizationProblem(py::class_<OptimizationProblem>& cls) {
   using namespace py::literals;
 
-  cls.def(py::init<>(), R"doc(Construct the optimization problem.)doc");
+  cls.def(py::init<>(),
+          DOC(sleipnir, OptimizationProblem, OptimizationProblem));
   cls.def("decision_variable",
           py::overload_cast<>(&OptimizationProblem::DecisionVariable),
           DOC(sleipnir, OptimizationProblem, DecisionVariable));


### PR DESCRIPTION
TrajoptLib's Rust bindings weren't calling callbacks more than once without it.