### PR TITLE
Fix include paths in C++ API docs

### DIFF
--- a/docs/Doxyfile-cpp
+++ b/docs/Doxyfile-cpp
@@ -193,7 +193,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = include
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't


### PR DESCRIPTION
The leading directory was being stripped.