### PR TITLE
Add regularization and number of backtracks to diagnostics

### DIFF
--- a/src/optimization/RegularizedLDLT.hpp
+++ b/src/optimization/RegularizedLDLT.hpp
@@ -115,7 +115,7 @@ class RegularizedLDLT {
   }
 
   /**
-   * Solve the system of equations using a regularized LDLT factorization.
+   * Solves the system of equations using a regularized LDLT factorization.
    *
    * @param rhs Right-hand side of the system.
    */
@@ -123,6 +123,11 @@ class RegularizedLDLT {
   auto Solve(const Eigen::MatrixBase<Rhs>& rhs) {
     return m_solver.solve(rhs);
   }
+
+  /**
+   * Returns the Hessian regularization factor.
+   */
+  double HessianRegularization() const { return m_δOld; }
 
  private:
   Solver m_solver;

--- a/src/optimization/solver/InteriorPoint.cpp
+++ b/src/optimization/solver/InteriorPoint.cpp
@@ -24,6 +24,7 @@
 #include "sleipnir/util/Print.hpp"
 #include "sleipnir/util/Spy.hpp"
 #include "sleipnir/util/small_vector.hpp"
+#include "util/PrintIterationDiagnostics.hpp"
 #include "util/ScopeExit.hpp"
 #include "util/ToMilliseconds.hpp"
 
@@ -786,19 +787,12 @@ void InteriorPoint(std::span<Variable> decisionVariables,
 
     const auto innerIterEndTime = std::chrono::steady_clock::now();
 
-    // Diagnostics for current iteration
     if (config.diagnostics) {
-      if (iterations % 20 == 0) {
-        sleipnir::println("{:^4}   {:^9}  {:^13}  {:^13}  {:^13}", "iter",
-                          "time (ms)", "error", "cost", "infeasibility");
-        sleipnir::println("{:=^61}", "");
-      }
-
-      sleipnir::println("{:4}{}  {:9.3f}  {:13e}  {:13e}  {:13e}", iterations,
-                        feasibilityRestoration ? "r" : " ",
-                        ToMilliseconds(innerIterEndTime - innerIterStartTime),
-                        E_0, f.Value(),
-                        c_e.lpNorm<1>() + (c_i - s).lpNorm<1>());
+      PrintIterationDiagnostics(iterations, feasibilityRestoration,
+                                innerIterEndTime - innerIterStartTime, E_0,
+                                f.Value(),
+                                c_e.lpNorm<1>() + (c_i - s).lpNorm<1>(),
+                                solver.HessianRegularization(), α);
     }
 
     ++iterations;

--- a/src/optimization/solver/Newton.cpp
+++ b/src/optimization/solver/Newton.cpp
@@ -19,6 +19,7 @@
 #include "sleipnir/optimization/SolverExitCondition.hpp"
 #include "sleipnir/util/Print.hpp"
 #include "sleipnir/util/Spy.hpp"
+#include "util/PrintIterationDiagnostics.hpp"
 #include "util/ScopeExit.hpp"
 #include "util/ToMilliseconds.hpp"
 
@@ -250,17 +251,10 @@ void Newton(std::span<Variable> decisionVariables, Variable& f,
 
     const auto innerIterEndTime = std::chrono::steady_clock::now();
 
-    // Diagnostics for current iteration
     if (config.diagnostics) {
-      if (iterations % 20 == 0) {
-        sleipnir::println("{:^4}   {:^9}  {:^13}  {:^13}  {:^13}", "iter",
-                          "time (ms)", "error", "cost", "infeasibility");
-        sleipnir::println("{:=^61}", "");
-      }
-
-      sleipnir::println("{:4}   {:9.3f}  {:13e}  {:13e}  {:13e}", iterations,
-                        ToMilliseconds(innerIterEndTime - innerIterStartTime),
-                        E_0, f.Value(), 0.0);
+      PrintIterationDiagnostics(
+          iterations, false, innerIterEndTime - innerIterStartTime, E_0,
+          f.Value(), 0.0, solver.HessianRegularization(), α);
     }
 
     ++iterations;

--- a/src/optimization/solver/SQP.cpp
+++ b/src/optimization/solver/SQP.cpp
@@ -23,6 +23,7 @@
 #include "sleipnir/util/Print.hpp"
 #include "sleipnir/util/Spy.hpp"
 #include "sleipnir/util/small_vector.hpp"
+#include "util/PrintIterationDiagnostics.hpp"
 #include "util/ScopeExit.hpp"
 #include "util/ToMilliseconds.hpp"
 
@@ -520,17 +521,10 @@ void SQP(std::span<Variable> decisionVariables,
 
     const auto innerIterEndTime = std::chrono::steady_clock::now();
 
-    // Diagnostics for current iteration
     if (config.diagnostics) {
-      if (iterations % 20 == 0) {
-        sleipnir::println("{:^4}   {:^9}  {:^13}  {:^13}  {:^13}", "iter",
-                          "time (ms)", "error", "cost", "infeasibility");
-        sleipnir::println("{:=^61}", "");
-      }
-
-      sleipnir::println("{:4}   {:9.3f}  {:13e}  {:13e}  {:13e}", iterations,
-                        ToMilliseconds(innerIterEndTime - innerIterStartTime),
-                        E_0, f.Value(), c_e.lpNorm<1>());
+      PrintIterationDiagnostics(
+          iterations, false, innerIterEndTime - innerIterStartTime, E_0,
+          f.Value(), c_e.lpNorm<1>(), solver.HessianRegularization(), α);
     }
 
     ++iterations;

--- a/src/util/PrintIterationDiagnostics.hpp
+++ b/src/util/PrintIterationDiagnostics.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) Sleipnir contributors
+
+#pragma once
+
+#include <chrono>
+#include <cmath>
+#include <ranges>
+#include <string>
+
+#include "sleipnir/util/Print.hpp"
+#include "sleipnir/util/small_vector.hpp"
+#include "util/ToMilliseconds.hpp"
+
+namespace sleipnir {
+
+/**
+ * Prints diagnostics for the current iteration.
+ *
+ * @param iterations Number of iterations.
+ * @param feasibilityRestoration Whether solver is in feasibility restoration
+ *     mode.
+ * @param time The iteration duration.
+ * @param error The error.
+ * @param cost The cost.
+ * @param infeasibility The infeasibility.
+ * @param δ The Hessian regularization factor.
+ * @param α The step size.
+ */
+template <typename Rep, typename Period = std::ratio<1>>
+void PrintIterationDiagnostics(int iterations, bool feasibilityRestoration,
+                               const std::chrono::duration<Rep, Period>& time,
+                               double error, double cost, double infeasibility,
+                               double δ, double α) {
+  if (iterations % 20 == 0) {
+    sleipnir::println("{:^4}   {:^9}  {:^13}  {:^13}  {:^13}  {:^4}  {:^10}",
+                      "iter", "time (ms)", "error", "cost", "infeasibility",
+                      "reg", "backtracks");
+    sleipnir::println("{:=^79}", "");
+  }
+
+  sleipnir::print("{:4}{}  {:9.3f}  {:13e}  {:13e}  {:13e}  ", iterations,
+                  feasibilityRestoration ? "r" : " ", ToMilliseconds(time),
+                  error, cost, infeasibility);
+
+  // Print regularization
+  if (δ == 0.0) {
+    sleipnir::print(" 0  ");
+  } else {
+    int exponent = std::log10(δ);
+
+    if (exponent == 0) {
+      sleipnir::print(" 1  ");
+    } else if (exponent == 1) {
+      sleipnir::print("10  ");
+    } else {
+      // Gather regularization exponent digits
+      int n = std::abs(exponent);
+      small_vector<int> digits;
+      do {
+        digits.emplace_back(n % 10);
+        n /= 10;
+      } while (n > 0);
+
+      std::string reg = "10";
+
+      // Append regularization exponent
+      if (exponent < 0) {
+        reg += "⁻";
+      }
+      constexpr const char* strs[] = {"⁰", "¹", "²", "³", "⁴",
+                                      "⁵", "⁶", "⁷", "⁸", "⁹"};
+      for (const auto& digit : std::ranges::views::reverse(digits)) {
+        reg += strs[digit];
+      }
+
+      sleipnir::print("{:<4}", reg);
+    }
+  }
+
+  sleipnir::println("  {:10d}", static_cast<int>(-std::log2(α)));
+}
+
+}  // namespace sleipnir


### PR DESCRIPTION
Examples:
```
iter   time (ms)      error          cost       infeasibility  reg   backtracks
===============================================================================
   0       3.832   5.279228e+02   2.613729e+01   5.940363e+03  10⁻⁴           5
   1       3.826   1.309315e+03   3.904672e+01   5.913762e+03  10⁻⁴           7
   2       3.624   2.908785e+01   6.829736e+01   5.873628e+03  10⁻⁴           7
   3       3.812   2.375783e+02   7.304661e+01   5.871579e+03   1            11
   4       3.889   2.134911e+03   8.013176e+01   5.864523e+03   1             9
   5       4.242   8.779660e+03   9.372899e+01   5.850240e+03   1             8
   6       3.649   1.020610e+04   1.161645e+02   5.830460e+03  10             8
   7       6.833   1.120983e+04   1.195454e+02   5.827803e+03  10            11
   8       4.110   5.651185e+03   1.318368e+02   5.818040e+03  10²            9
   9       3.799   4.857091e+03   1.456865e+02   5.802622e+03  10³            8
  10       3.714   2.335885e+04   1.511013e+02   5.793224e+03  10³            9
  11       3.557   7.149313e+03   1.572301e+02   5.784683e+03  10³            9
  12       3.815   4.958424e+04   2.470276e+02   5.629232e+03  10⁴            5
  13       3.669   3.003325e+04   3.419977e+02   5.501672e+03  10⁴            5
  14       3.572   2.434288e+04   3.422190e+02   5.501421e+03  10³           14
  15       3.924   4.215715e+04   1.074048e+03   4.777672e+03  10⁴            3
  16       4.551   2.005596e+04   3.105042e+03   3.628277e+03  10⁴            2
  17       3.758   1.770806e+05   3.808402e+03   3.339475e+03  10³            3
  18       3.809   2.394209e+04   7.134606e+03   2.121278e+03  10⁴            1
  19       3.588   2.813119e+04   7.164151e+03   2.112274e+03  10⁴            7
iter   time (ms)      error          cost       infeasibility  reg   backtracks
===============================================================================
  20      21.466   2.826093e+04   7.164151e+03   2.112134e+03  10⁴           13
  21       4.764   2.567895e+04   7.164154e+03   2.112133e+03  10³           21
  22       3.811   2.742097e+04   7.164916e+03   2.111872e+03  10⁴           12
  23       3.678   3.261816e+03   7.444860e+03   2.022223e+03  10⁴            4
  24       3.830   2.502083e+04   7.505754e+03   2.004529e+03  10⁴            6
iter   time (ms)      error          cost       infeasibility  reg   backtracks
===============================================================================
   0r     16.724   2.690442e+04  -6.433055e+09   6.440839e+06   0             9
   1r     16.102   2.688440e+04  -6.428267e+09   6.436044e+06   0            10
   2r     15.655   2.476523e+04  -5.921558e+09   5.928723e+06   0             3
   3r     15.605   2.112236e+04  -5.050519e+09   5.056632e+06   0             2

```
```
iter   time (ms)      error          cost       infeasibility  reg   backtracks
===============================================================================
   0       2.430   1.771198e+05   5.227495e+01   1.282972e+02  10⁻⁴           0
   1       2.722   4.466788e+03   2.363619e+01   2.132855e+01  10⁴            0
   2       2.392   8.546946e+02   2.561887e+01   3.128966e+00  10⁵            0
   3       2.662   2.470021e+04   2.780689e+00   1.573462e+01  10⁶           11
   4       2.174   1.836587e+04   8.117697e+00   9.060743e+00  10⁶            0
   5       2.131   3.900276e+02   9.675301e+00   6.205808e+00  10⁶            0
   6       3.036   5.709649e+04   7.067670e+00   2.081428e+01  10⁷            0
   7      20.013   2.457931e+05   7.923420e+00   1.640462e+01  10⁷            7
   8       2.380   7.171578e+04   8.007898e+00   1.294796e+01  10⁷            0
   9       2.141   3.308662e+04   8.147714e+00   7.381907e+00  10⁷            0
```