### PR TITLE
Guard spy and warning print with DISABLE_DIAGNOSTICS flag

### DIFF
--- a/include/sleipnir/autodiff/Variable.hpp
+++ b/include/sleipnir/autodiff/Variable.hpp
@@ -17,9 +17,12 @@
 #include "sleipnir/autodiff/ValueExpressionGraph.hpp"
 #include "sleipnir/util/Assert.hpp"
 #include "sleipnir/util/Concepts.hpp"
-#include "sleipnir/util/Print.hpp"
 #include "sleipnir/util/SymbolExports.hpp"
 #include "sleipnir/util/small_vector.hpp"
+
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
+#include "sleipnir/util/Print.hpp"
+#endif
 
 namespace sleipnir {
 
@@ -96,6 +99,7 @@ class SLEIPNIR_DLLEXPORT Variable {
     if (expr->IsConstant(0.0)) {
       expr = detail::MakeExpressionPtr<detail::ConstExpression>(value);
     } else {
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
       // We only need to check the first argument since unary and binary
       // operators both use it
       if (expr->args[0] != nullptr) {
@@ -105,6 +109,7 @@ class SLEIPNIR_DLLEXPORT Variable {
             "WARNING: {}:{}: {}: Modified the value of a dependent variable",
             location.file_name(), location.line(), location.function_name());
       }
+#endif
       expr->value = value;
     }
   }

--- a/jormungandr/cpp/Docstrings.hpp
+++ b/jormungandr/cpp/Docstrings.hpp
@@ -27,21 +27,21 @@ static const char *__doc_Eigen_NumTraits =
 R"doc(NumTraits specialization that allows instantiating Eigen types with
 Variable.)doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3 = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3 = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_AddCost = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_AddCost = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_IsComplex = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_IsComplex = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_IsInteger = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_IsInteger = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_IsSigned = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_IsSigned = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_MulCost = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_MulCost = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_ReadCost = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_ReadCost = R"doc()doc";
 
-static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_777_3_RequireInitialization = R"doc()doc";
+static const char *__doc_Eigen_NumTraits_unnamed_enum_at_home_tav_git_Sleipnir_include_sleipnir_autodiff_Variable_hpp_782_3_RequireInitialization = R"doc()doc";
 
 static const char *__doc_sleipnir_Block =
 R"doc(Assemble a VariableMatrix from a nested list of blocks.

--- a/src/optimization/solver/InteriorPoint.cpp
+++ b/src/optimization/solver/InteriorPoint.cpp
@@ -25,12 +25,12 @@
 #include "sleipnir/util/ScopedProfiler.hpp"
 #include "sleipnir/util/SetupProfiler.hpp"
 #include "sleipnir/util/SolveProfiler.hpp"
-#include "sleipnir/util/Spy.hpp"
 #include "sleipnir/util/small_vector.hpp"
 #include "util/ScopeExit.hpp"
 
 #ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
 #include "sleipnir/util/Print.hpp"
+#include "sleipnir/util/Spy.hpp"
 #include "util/PrintDiagnostics.hpp"
 #endif
 
@@ -175,6 +175,7 @@ void InteriorPoint(
 
   setupProfilers.back().Stop();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
   // Sparsity pattern files written when spy flag is set in SolverConfig
   std::unique_ptr<Spy> H_spy;
   std::unique_ptr<Spy> A_e_spy;
@@ -193,6 +194,7 @@ void InteriorPoint(
         "lhs.spy", "Newton-KKT system left-hand side", "Rows", "Columns",
         H.rows() + A_e.rows(), H.cols() + A_e.rows());
   }
+#endif
 
   int iterations = 0;
 
@@ -274,6 +276,7 @@ void InteriorPoint(
   auto& linearSystemSolveProf = solveProfilers[4];
   auto& lineSearchProf = solveProfilers[5];
   auto& socProf = solveProfilers[6];
+  [[maybe_unused]]
   auto& spyWritesProf = solveProfilers[7];
   auto& nextIterPrepProf = solveProfilers[8];
 
@@ -678,6 +681,7 @@ void InteriorPoint(
 
     lineSearchProfiler.Stop();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
     // Write out spy file contents if that's enabled
     if (config.spy) {
       ScopedProfiler spyWritesProfiler{spyWritesProf};
@@ -686,6 +690,7 @@ void InteriorPoint(
       A_i_spy->Add(A_i);
       lhs_spy->Add(lhs);
     }
+#endif
 
     // If full step was accepted, reset full-step rejected counter
     if (α == α_max) {

--- a/src/optimization/solver/Newton.cpp
+++ b/src/optimization/solver/Newton.cpp
@@ -22,11 +22,11 @@
 #include "sleipnir/util/ScopedProfiler.hpp"
 #include "sleipnir/util/SetupProfiler.hpp"
 #include "sleipnir/util/SolveProfiler.hpp"
-#include "sleipnir/util/Spy.hpp"
 #include "util/ScopeExit.hpp"
 
 #ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
 #include "sleipnir/util/Print.hpp"
+#include "sleipnir/util/Spy.hpp"
 #include "util/PrintDiagnostics.hpp"
 #endif
 
@@ -92,6 +92,7 @@ void Newton(
   setupProfilers.back().Stop();
   setupProfilers.emplace_back("  ↳ spy setup").Start();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
   // Sparsity pattern files written when spy flag is set in SolverConfig
   std::unique_ptr<Spy> H_spy;
   std::unique_ptr<Spy> lhs_spy;
@@ -102,6 +103,7 @@ void Newton(
         std::make_unique<Spy>("lhs.spy", "Newton-KKT system left-hand side",
                               "Rows", "Columns", H.rows(), H.cols());
   }
+#endif
 
   setupProfilers.back().Stop();
 
@@ -135,6 +137,7 @@ void Newton(
   auto& userCallbacksProf = solveProfilers[2];
   auto& linearSystemSolveProf = solveProfilers[3];
   auto& lineSearchProf = solveProfilers[4];
+  [[maybe_unused]]
   auto& spyWritesProf = solveProfilers[5];
   auto& nextIterPrepProf = solveProfilers[6];
 
@@ -280,12 +283,14 @@ void Newton(
 
     lineSearchProfiler.Stop();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
     // Write out spy file contents if that's enabled
     if (config.spy) {
       ScopedProfiler spyWritesProfiler{spyWritesProf};
       H_spy->Add(H);
       lhs_spy->Add(H);
     }
+#endif
 
     // xₖ₊₁ = xₖ + αₖpₖˣ
     x += α * p_x;

--- a/src/optimization/solver/SQP.cpp
+++ b/src/optimization/solver/SQP.cpp
@@ -24,12 +24,12 @@
 #include "sleipnir/util/ScopedProfiler.hpp"
 #include "sleipnir/util/SetupProfiler.hpp"
 #include "sleipnir/util/SolveProfiler.hpp"
-#include "sleipnir/util/Spy.hpp"
 #include "sleipnir/util/small_vector.hpp"
 #include "util/ScopeExit.hpp"
 
 #ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
 #include "sleipnir/util/Print.hpp"
+#include "sleipnir/util/Spy.hpp"
 #include "util/PrintDiagnostics.hpp"
 #endif
 
@@ -143,6 +143,7 @@ void SQP(
   setupProfilers.back().Stop();
   setupProfilers.emplace_back("  ↳ spy setup").Start();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
   // Sparsity pattern files written when spy flag is set in SolverConfig
   std::unique_ptr<Spy> H_spy;
   std::unique_ptr<Spy> A_e_spy;
@@ -157,6 +158,7 @@ void SQP(
         "lhs.spy", "Newton-KKT system left-hand side", "Rows", "Columns",
         H.rows() + A_e.rows(), H.cols() + A_e.rows());
   }
+#endif
 
   setupProfilers.back().Stop();
 
@@ -199,6 +201,7 @@ void SQP(
   auto& linearSystemSolveProf = solveProfilers[4];
   auto& lineSearchProf = solveProfilers[5];
   auto& socProf = solveProfilers[6];
+  [[maybe_unused]]
   auto& spyWritesProf = solveProfilers[7];
   auto& nextIterPrepProf = solveProfilers[8];
 
@@ -499,6 +502,7 @@ void SQP(
 
     lineSearchProfiler.Stop();
 
+#ifndef SLEIPNIR_DISABLE_DIAGNOSTICS
     // Write out spy file contents if that's enabled
     if (config.spy) {
       ScopedProfiler spyWritesProfiler{spyWritesProf};
@@ -506,6 +510,7 @@ void SQP(
       A_e_spy->Add(A_e);
       lhs_spy->Add(lhs);
     }
+#endif
 
     // If full step was accepted, reset full-step rejected counter
     if (α == α_max) {

--- a/tools/perf-benchmark.sh
+++ b/tools/perf-benchmark.sh
@@ -6,7 +6,7 @@ if [[ $# -ne 1 ]] || [[ "$1" != "CartPole" && "$1" != "Flywheel" ]]; then
   exit 1
 fi
 
-cmake -B build-perf -S . -DCMAKE_BUILD_TYPE=Perf -DBUILD_BENCHMARKS=ON
+cmake -B build-perf -S . -DCMAKE_BUILD_TYPE=Perf -DBUILD_BENCHMARKS=ON -DDISABLE_DIAGNOSTICS=ON
 cmake --build build-perf --target $1PerfBenchmark
 ./tools/perf-record.sh ./build-perf/$1PerfBenchmark
 ./tools/perf-report.sh


### PR DESCRIPTION
This cleans up irrelevant symbols in hotspot's output.