### PR TITLE
Remove value list from AdjointExpressionGraph

### DIFF
--- a/include/sleipnir/autodiff/ValueExpressionGraph.hpp
+++ b/include/sleipnir/autodiff/ValueExpressionGraph.hpp
@@ -56,11 +56,7 @@ class ValueExpressionGraph {
       auto node = stack.back();
       stack.pop_back();
 
-      if (node->args[0] != nullptr) {
-        // Constants (expressions with no arguments) are skipped because they
-        // don't need to be updated
-        m_valueList.emplace_back(node);
-      }
+      m_topList.emplace_back(node);
 
       for (auto& arg : node->args) {
         // If we traversed all this node's incoming edges, add it to the stack
@@ -76,9 +72,8 @@ class ValueExpressionGraph {
    * their dependent nodes.
    */
   void Update() {
-    // Traverse the BFS list backward from child to parent and update the value
-    // of each node.
-    for (auto& node : m_valueList | std::views::reverse) {
+    // Traverse graph from child to parent and update values
+    for (auto& node : m_topList | std::views::reverse) {
       auto& lhs = node->args[0];
       auto& rhs = node->args[1];
 
@@ -93,8 +88,8 @@ class ValueExpressionGraph {
   }
 
  private:
-  // List for updating values
-  small_vector<Expression*> m_valueList;
+  // Topological sort of graph from parent to child
+  small_vector<Expression*> m_topList;
 };
 
 }  // namespace sleipnir::detail

--- a/jormungandr/cpp/Docstrings.hpp
+++ b/jormungandr/cpp/Docstrings.hpp
@@ -1977,11 +1977,9 @@ static const char *__doc_sleipnir_detail_AdjointExpressionGraph_Update =
 R"doc(Update the values of all nodes in this adjoint graph based on the
 values of their dependent nodes.)doc";
 
-static const char *__doc_sleipnir_detail_AdjointExpressionGraph_m_adjointList = R"doc()doc";
-
 static const char *__doc_sleipnir_detail_AdjointExpressionGraph_m_colList = R"doc()doc";
 
-static const char *__doc_sleipnir_detail_AdjointExpressionGraph_m_valueList = R"doc()doc";
+static const char *__doc_sleipnir_detail_AdjointExpressionGraph_m_topList = R"doc()doc";
 
 static const char *__doc_sleipnir_detail_AsinExpression = R"doc()doc";
 
@@ -2584,7 +2582,7 @@ R"doc(Generates the value graph for the given expression.
 Parameter ``root``:
     The root node of the expression.)doc";
 
-static const char *__doc_sleipnir_detail_ValueExpressionGraph_m_valueList = R"doc()doc";
+static const char *__doc_sleipnir_detail_ValueExpressionGraph_m_topList = R"doc()doc";
 
 static const char *__doc_sleipnir_detail_abs =
 R"doc(std::abs() for Expressions.


### PR DESCRIPTION
The benchmarks and a few unit tests I ran don't show a performance regression, so this simplifies the code.