### PR TITLE
Use dense linear system solver on dense problems

### DIFF
--- a/jormungandr/test/optimization/nonlinear_problem_test.py
+++ b/jormungandr/test/optimization/nonlinear_problem_test.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy as np
 import pytest
 
@@ -107,9 +109,13 @@ def test_narrow_feasible_region():
     assert status.cost_function_type == ExpressionType.NONLINEAR
     assert status.equality_constraint_type == ExpressionType.LINEAR
     assert status.inequality_constraint_type == ExpressionType.NONE
-    # FIXME: Fails with "diverging iterates"
-    assert status.exit_condition == SolverExitCondition.DIVERGING_ITERATES
-    return
+
+    if platform.system() == "Linux" and platform.machine() == "aarch64":
+        # FIXME: Fails on Linux aarch64 with "diverging iterates"
+        assert status.exit_condition == SolverExitCondition.DIVERGING_ITERATES
+        return
+    else:
+        assert status.exit_condition == SolverExitCondition.SUCCESS
 
     assert x.value() == pytest.approx(2.5, abs=1e-2)
     assert y.value() == pytest.approx(2.5, abs=1e-2)

--- a/src/optimization/solver/InteriorPoint.cpp
+++ b/src/optimization/solver/InteriorPoint.cpp
@@ -462,8 +462,8 @@ void InteriorPoint(
     //
     // [H + AᵢᵀΣAᵢ  Aₑᵀ][ pₖˣ] = −[∇f − Aₑᵀy + Aᵢᵀ(S⁻¹(Zcᵢ − μe) − z)]
     // [    Aₑ       0 ][−pₖʸ]    [                cₑ                ]
-    solver.Compute(lhs, equalityConstraints.size(), μ);
-    if (solver.Info() != Eigen::Success) [[unlikely]] {
+    if (solver.Compute(lhs, equalityConstraints.size(), μ).Info() !=
+        Eigen::Success) [[unlikely]] {
       status->exitCondition = SolverExitCondition::kFactorizationFailed;
       return;
     }

--- a/src/optimization/solver/SQP.cpp
+++ b/src/optimization/solver/SQP.cpp
@@ -336,8 +336,8 @@ void SQP(
     //
     // [H   Aₑᵀ][ pₖˣ] = −[∇f − Aₑᵀy]
     // [Aₑ   0 ][−pₖʸ]    [   cₑ    ]
-    solver.Compute(lhs, equalityConstraints.size(), config.tolerance / 10.0);
-    if (solver.Info() != Eigen::Success) [[unlikely]] {
+    if (solver.Compute(lhs, equalityConstraints.size(), config.tolerance / 10.0)
+            .Info() != Eigen::Success) [[unlikely]] {
       status->exitCondition = SolverExitCondition::kFactorizationFailed;
       return;
     }

--- a/test/src/optimization/NonlinearProblemTest.cpp
+++ b/test/src/optimization/NonlinearProblemTest.cpp
@@ -124,9 +124,15 @@ TEST_CASE("NonlinearProblem - Narrow feasible region", "[NonlinearProblem]") {
   CHECK(status.costFunctionType == sleipnir::ExpressionType::kNonlinear);
   CHECK(status.equalityConstraintType == sleipnir::ExpressionType::kLinear);
   CHECK(status.inequalityConstraintType == sleipnir::ExpressionType::kNone);
+
+#if defined(__linux__) && defined(__aarch64__)
+  // FIXME: Fails on Linux aarch64 with "diverging iterates"
   CHECK(status.exitCondition ==
         sleipnir::SolverExitCondition::kDivergingIterates);
   SKIP("Fails with \"diverging iterates\"");
+#else
+  CHECK(status.exitCondition == sleipnir::SolverExitCondition::kSuccess);
+#endif
 
   CHECK(x.Value() == Catch::Approx(2.5).margin(1e-2));
   CHECK(y.Value() == Catch::Approx(2.5).margin(1e-2));


### PR DESCRIPTION
Before with `OCPSolver Flywheel Explicit Single-Shooting` test:
```
Time: 4503.842 ms
  ↳ setup: 960.002 ms
  ↳ solve: 3543.840 ms (17 iterations)

┏━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┓
┃        trace        │     percent      │total (ms)┃
┡━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┩
│setup                 100.00%▕█████████▏    960.002│
│  ↳ s,y,z setup         0.00%▕         ▏      0.045│
│  ↳ L setup             0.01%▕         ▏      0.125│
│  ↳ ∂cₑ/∂x setup        0.00%▕         ▏      0.006│
│  ↳ ∂cₑ/∂x init solve   0.00%▕         ▏      0.000│
│  ↳ ∂cᵢ/∂x setup        0.01%▕         ▏      0.120│
│  ↳ ∂cᵢ/∂x init solve   0.00%▕         ▏      0.000│
│  ↳ ∇f(x) setup         0.04%▕         ▏      0.394│
│  ↳ ∇f(x) init solve    0.02%▕         ▏      0.208│
│  ↳ ∇²ₓₓL setup        99.70%▕████████▉▏    957.167│
│  ↳ ∇²ₓₓL init solve    0.08%▕         ▏      0.807│
│  ↳ precondition ✓      0.12%▕         ▏      1.119│
└───────────────────────────────────────────────────┘
┏━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━┯━━━━┓
┃        trace        │     percent      │total (ms)│each (ms)│runs┃
┡━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━┷━━━━┩
│solve                 100.00%▕█████████▏   3543.840   208.461   17│
│  ↳ feasibility ✓       0.00%▕         ▏      0.138     0.008   17│
│  ↳ user callbacks      0.00%▕         ▏      0.000     0.000   17│
│  ↳ iter matrix build   1.78%▕▏        ▏     63.095     3.711   17│
│  ↳ iter matrix solve  97.17%▕████████▋▏   3443.435   202.555   17│
│  ↳ line search         0.26%▕         ▏      9.129     0.537   17│
│    ↳ SOC               0.00%▕         ▏      0.000     0.000    0│
│  ↳ spy writes          0.00%▕         ▏      0.000     0.000    0│
│  ↳ next iter prep      0.04%▕         ▏      1.333     0.078   17│
│  ↳ ∇f(x)               0.27%▕         ▏      9.617     0.534   18│
│    ↳ graph update      0.09%▕         ▏      3.297     0.183   18│
│    ↳ adjoints          0.17%▕         ▏      6.195     0.344   18│
│    ↳ matrix build      0.00%▕         ▏      0.118     0.006   18│
│  ↳ ∇²ₓₓL               0.00%▕         ▏      0.000     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
│  ↳ ∂cₑ/∂x              0.00%▕         ▏      0.000     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
│  ↳ ∂cᵢ/∂x              0.00%▕         ▏      0.001     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
└──────────────────────────────────────────────────────────────────┘
```
After with `OCPSolver Flywheel Explicit Single-Shooting` test:
```
Time: 1845.651 ms
  ↳ setup: 936.334 ms
  ↳ solve: 909.317 ms (17 iterations)

┏━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┓
┃        trace        │     percent      │total (ms)┃
┡━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┩
│setup                 100.00%▕█████████▏    936.334│
│  ↳ s,y,z setup         0.01%▕         ▏      0.066│
│  ↳ L setup             0.01%▕         ▏      0.140│
│  ↳ ∂cₑ/∂x setup        0.00%▕         ▏      0.008│
│  ↳ ∂cₑ/∂x init solve   0.00%▕         ▏      0.001│
│  ↳ ∂cᵢ/∂x setup        0.01%▕         ▏      0.139│
│  ↳ ∂cᵢ/∂x init solve   0.00%▕         ▏      0.000│
│  ↳ ∇f(x) setup         0.05%▕         ▏      0.458│
│  ↳ ∇f(x) init solve    0.03%▕         ▏      0.266│
│  ↳ ∇²ₓₓL setup        99.65%▕████████▉▏    933.041│
│  ↳ ∇²ₓₓL init solve    0.09%▕         ▏      0.862│
│  ↳ precondition ✓      0.14%▕         ▏      1.343│
└───────────────────────────────────────────────────┘
┏━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━┯━━━━━━━━━┯━━━━┓
┃        trace        │     percent      │total (ms)│each (ms)│runs┃
┡━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━┷━━━━━━━━━┷━━━━┩
│solve                 100.00%▕█████████▏    909.317    53.489   17│
│  ↳ feasibility ✓       0.01%▕         ▏      0.131     0.007   17│
│  ↳ user callbacks      0.00%▕         ▏      0.000     0.000   17│
│  ↳ iter matrix build   6.78%▕▌        ▏     61.696     3.629   17│
│  ↳ iter matrix solve  89.68%▕████████ ▏    815.504    47.970   17│
│  ↳ line search         0.82%▕         ▏      7.442     0.437   17│
│    ↳ SOC               0.00%▕         ▏      0.000     0.000    0│
│  ↳ spy writes          0.00%▕         ▏      0.000     0.000    0│
│  ↳ next iter prep      0.16%▕         ▏      1.494     0.087   17│
│  ↳ ∇f(x)               0.51%▕         ▏      4.608     0.256   18│
│    ↳ graph update      0.16%▕         ▏      1.471     0.081   18│
│    ↳ adjoints          0.33%▕         ▏      3.015     0.167   18│
│    ↳ matrix build      0.01%▕         ▏      0.117     0.006   18│
│  ↳ ∇²ₓₓL               0.00%▕         ▏      0.000     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
│  ↳ ∂cₑ/∂x              0.00%▕         ▏      0.001     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
│  ↳ ∂cᵢ/∂x              0.00%▕         ▏      0.001     0.000   18│
│    ↳ graph update      0.00%▕         ▏      0.000     0.000    0│
│    ↳ adjoints          0.00%▕         ▏      0.000     0.000    0│
│    ↳ matrix build      0.00%▕         ▏      0.000     0.000    0│
└──────────────────────────────────────────────────────────────────┘
```