### PR TITLE
Remove slack variables from solver iteration info

### DIFF
--- a/include/sleipnir/optimization/solver/iteration_info.hpp
+++ b/include/sleipnir/optimization/solver/iteration_info.hpp
@@ -17,9 +17,6 @@ struct IterationInfo {
   /// The decision variables.
   const Eigen::VectorXd& x;
 
-  /// The inequality constraint slack variables.
-  const Eigen::VectorXd& s;
-
   /// The gradient of the cost function.
   const Eigen::SparseVector<double>& g;
 

--- a/src/optimization/solver/interior_point.cpp
+++ b/src/optimization/solver/interior_point.cpp
@@ -370,7 +370,7 @@ ExitStatus interior_point(
 
     // Call user callbacks
     for (const auto& callback : callbacks) {
-      if (callback({iterations, x, s, g, H, A_e, A_i})) {
+      if (callback({iterations, x, g, H, A_e, A_i})) {
         return ExitStatus::CALLBACK_REQUESTED_STOP;
       }
     }

--- a/src/optimization/solver/newton.cpp
+++ b/src/optimization/solver/newton.cpp
@@ -182,8 +182,7 @@ ExitStatus newton(
 
     // Call user callbacks
     for (const auto& callback : callbacks) {
-      if (callback({iterations, x, Eigen::VectorXd::Zero(0), g, H,
-                    Eigen::SparseMatrix<double>{},
+      if (callback({iterations, x, g, H, Eigen::SparseMatrix<double>{},
                     Eigen::SparseMatrix<double>{}})) {
         return ExitStatus::CALLBACK_REQUESTED_STOP;
       }

--- a/src/optimization/solver/sqp.cpp
+++ b/src/optimization/solver/sqp.cpp
@@ -270,8 +270,7 @@ ExitStatus sqp(
 
     // Call user callbacks
     for (const auto& callback : callbacks) {
-      if (callback({iterations, x, Eigen::VectorXd::Zero(0), g, H, A_e,
-                    Eigen::SparseMatrix<double>{}})) {
+      if (callback({iterations, x, g, H, A_e, Eigen::SparseMatrix<double>{}})) {
         return ExitStatus::CALLBACK_REQUESTED_STOP;
       }
     }


### PR DESCRIPTION
It was used by the feasibility restoration phase, but that was removed.