### PR TITLE
Remove Linux aarch64 job for disabled diagnostics

### DIFF
--- a/.github/workflows/build-cpp.yml
+++ b/.github/workflows/build-cpp.yml
@@ -28,9 +28,6 @@ jobs:
           - name: Linux x86_64 (disable diagnostics)
             os: ubuntu-24.04
             cmake-args: -DDISABLE_DIAGNOSTICS=ON
-          - name: Linux aarch64 (disable diagnostics)
-            os: ubuntu-24.04-arm
-            cmake-args: -DDISABLE_DIAGNOSTICS=ON
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We only need one job to confirm that configuration builds and passes tests.