### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -15,10 +15,6 @@ jobs:
         include:
           - name: Windows x86_64
             os: windows-2022
-            version: "3.9"
-            cmake-env:
-          - name: Windows x86_64
-            os: windows-2022
             version: "3.10"
             cmake-env:
           - name: Windows x86_64
@@ -35,10 +31,6 @@ jobs:
             cmake-env:
           - name: Linux x86_64
             os: ubuntu-24.04
-            version: "3.9"
-            cmake-env:
-          - name: Linux x86_64
-            os: ubuntu-24.04
             version: "3.10"
             cmake-env:
           - name: Linux x86_64
@@ -52,10 +44,6 @@ jobs:
           - name: Linux x86_64
             os: ubuntu-24.04
             version: "3.13"
-            cmake-env:
-          - name: Linux aarch64
-            os: ubuntu-24.04-arm
-            version: "3.9"
             cmake-env:
           - name: Linux aarch64
             os: ubuntu-24.04-arm
@@ -111,7 +99,7 @@ jobs:
           python-version: ${{ matrix.version }}
 
       - run: pip install typing_extensions
-        if: matrix.version == '3.9' || matrix.version == '3.10'
+        if: matrix.version == '3.10'
 
       - run: python3 ./tools/update_version.py
       - run: pip3 install build pytest

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See the [examples](https://github.com/SleipnirGroup/Sleipnir/tree/main/examples)
   * On Windows, install from the link above
   * On Linux, install via `sudo apt install cmake`
   * On macOS, install via `brew install cmake`
-* [Python](https://www.python.org/downloads/) 3.9 or greater
+* [Python](https://www.python.org/downloads/) 3.10 or greater
   * On Windows, install from the link above
   * On Linux, install via `sudo apt install python`
   * On macOS, install via `brew install python`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sleipnirgroup-jormungandr"
 description = "A linearity-exploiting sparse nonlinear constrained optimization problem solver that uses the interior-point method."
 version = "0.0.1.dev369"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [ "matplotlib", "numpy", "scipy" ]
 
   [project.license]


### PR DESCRIPTION
https://devguide.python.org/versions/ says it's end-of-life by 2025-10.