### PR TITLE
Fix development release versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sleipnirgroup-jormungandr"
 description = "A linearity-exploiting sparse nonlinear constrained optimization problem solver that uses the interior-point method."
-version = "0.1.0"
+version = "0.1.1.dev3"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [ "matplotlib", "numpy", "scipy" ]

--- a/tools/update_version.py
+++ b/tools/update_version.py
@@ -19,15 +19,19 @@ def main():
         version = "0.0.0"
     else:
         m = re.search(
-            r"^v ([0-9]+\.[0-9]+\.[0-9]+) (- ([0-9]+) )?",
+            r"^v ([0-9]+) \. ([0-9]+) \. ([0-9]+) (- ([0-9]+) )?",
             proc.stdout.rstrip(),
             re.X,
         )
 
-        # Version number: <tag>.dev<# commits since tag>
-        version = m.group(1)
-        if m.group(2):
-            version += f".dev{m.group(3)}"
+        # Version number: <tag> or <tag + 1>.dev<# commits since tag>
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        patch = int(m.group(3))
+        if m.group(4):
+            version = f"{major}.{minor}.{patch + 1}.dev{m.group(5)}"
+        else:
+            version = f"{major}.{minor}.{patch}"
 
     # Update version string in pyproject.toml
     with open("pyproject.toml") as f:


### PR DESCRIPTION
Development releases are sorted before the associated release version, so we have to increment the release version.