### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -15,10 +15,6 @@ jobs:
         include:
           - name: Windows x86_64
             os: windows-2022
-            version: "3.10"
-            cmake-env:
-          - name: Windows x86_64
-            os: windows-2022
             version: "3.11"
             cmake-env:
           - name: Windows x86_64
@@ -28,10 +24,6 @@ jobs:
           - name: Windows x86_64
             os: windows-2022
             version: "3.13"
-            cmake-env:
-          - name: Linux x86_64
-            os: ubuntu-24.04
-            version: "3.10"
             cmake-env:
           - name: Linux x86_64
             os: ubuntu-24.04
@@ -47,10 +39,6 @@ jobs:
             cmake-env:
           - name: Linux aarch64
             os: ubuntu-24.04-arm
-            version: "3.10"
-            cmake-env:
-          - name: Linux aarch64
-            os: ubuntu-24.04-arm
             version: "3.11"
             cmake-env:
           - name: Linux aarch64
@@ -61,10 +49,6 @@ jobs:
             os: ubuntu-24.04-arm
             version: "3.13"
             cmake-env:
-          - name: macOS universal
-            os: macOS-14
-            version: "3.10"
-            cmake-env: _PYTHON_HOST_PLATFORM=macosx_14_0_universal2 ARCHFLAGS="-arch x86_64 -arch arm64" MACOSX_DEPLOYMENT_TARGET=14.0
           - name: macOS universal
             os: macOS-14
             version: "3.11"
@@ -97,9 +81,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
-
-      - run: pip install typing_extensions
-        if: matrix.version == '3.10'
 
       - run: python3 ./tools/update_version.py
       - run: pip3 install build pytest

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See the [examples](https://github.com/SleipnirGroup/Sleipnir/tree/main/examples)
   * On Windows, install from the link above
   * On Linux, install via `sudo apt install cmake`
   * On macOS, install via `brew install cmake`
-* [Python](https://www.python.org/downloads/) 3.10 or greater
+* [Python](https://www.python.org/downloads/) 3.11 or greater
   * On Windows, install from the link above
   * On Linux, install via `sudo apt install python`
   * On macOS, install via `brew install python`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sleipnirgroup-jormungandr"
 description = "A linearity-exploiting sparse nonlinear constrained optimization problem solver that uses the interior-point method."
 version = "0.1.1.dev3"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [ "matplotlib", "numpy", "scipy" ]
 
   [project.license]
@@ -17,7 +17,6 @@ requires = [
   "nanobind",
   "py-build-cmake~=0.4.3",
   "pybind11-mkdoc",
-  "typing_extensions; python_version < '3.11'"
 ]
 build-backend = "py_build_cmake.build"
 


### PR DESCRIPTION
We need math.cbrt() from Python 3.11 for cbrt() autodiff tests.