### PR TITLE
Increase speed of solver during feasibility restoration by ~90x

### DIFF
--- a/include/sleipnir/optimization/solver/util/regularized_ldlt.hpp
+++ b/include/sleipnir/optimization/solver/util/regularized_ldlt.hpp
@@ -68,11 +68,12 @@ class RegularizedLDLT {
     // We consider less than 25% to be sparse.
     m_is_sparse = lhs.nonZeros() < 0.25 * lhs.size();
 
+    // Regularization with zeros ensures the pattern analysis in
+    // compute_sparse() is reused by all factorizations
     m_info =
         m_is_sparse
             ? compute_sparse(lhs + regularization(Scalar(0), Scalar(0))).info()
-            : m_dense_solver.compute(lhs + regularization(Scalar(0), Scalar(0)))
-                  .info();
+            : m_dense_solver.compute(lhs).info();
 
     if (m_info == Eigen::Success) {
       auto D =

--- a/include/sleipnir/optimization/solver/util/regularized_ldlt.hpp
+++ b/include/sleipnir/optimization/solver/util/regularized_ldlt.hpp
@@ -68,8 +68,11 @@ class RegularizedLDLT {
     // We consider less than 25% to be sparse.
     m_is_sparse = lhs.nonZeros() < 0.25 * lhs.size();
 
-    m_info = m_is_sparse ? compute_sparse(lhs).info()
-                         : m_dense_solver.compute(lhs).info();
+    m_info =
+        m_is_sparse
+            ? compute_sparse(lhs + regularization(Scalar(0), Scalar(0))).info()
+            : m_dense_solver.compute(lhs + regularization(Scalar(0), Scalar(0)))
+                  .info();
 
     if (m_info == Eigen::Success) {
       auto D =


### PR DESCRIPTION
Large Choreo problems have really long feasibility restoration times - one problem I've been testing recently has approx 80ms normal iterations and 9200ms feasibility restoration iterations. Some debug printing showed that during feasibility restoration, 97% of time was being spent factorizing the KKT matrix. The fix adds zero to the KKT matrix before computing the LDLT decomposition, which reduces solve times from 9200ms to a much more reasonable 100ms. 

My best guess as to why this works is that Eigen handles decomposing the matrix differently when the sparsity pattern is changed since regularization adds a dense vector to the sparse matrix.