### PR TITLE
Implement automatic problem scaling

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -441,6 +441,59 @@ where αₖᵐᵃˣ and αₖᶻ are computed via the fraction-to-the-boundary r
 
 Section 6 of [^3] describes how to check for local infeasibility.
 
+## Problem scaling
+
+Sleipnir scales the cost and constraints to improve numerical stability. The objective and each constraint are scaled so that the largest gradient component at the starting point is at most `g_max`. For an initial point `x₀`, define
+
+```
+  d_f    = min(1, g_max / ‖∇f(x₀)‖_∞)
+  d_c[j] = min(1, g_max / ‖∇c_j(x₀)‖_∞)
+```
+
+where `D_c = diag(d_c)` and `A = ∂c/∂x` is the constraint Jacobian. The scaled Lagrangian is:
+
+```
+  L(x, λ) = d_f f(x) + λᵀ D_c c(x)
+```
+
+The Hessian of the scaled Lagrangian with respect to `x` is:
+
+```
+  ∇²ₓₓL(x, λ) = d_f ∇²ₓₓ f(x) + Σ_i (D_c λ)_i ∇²ₓₓ c_i(x)
+```
+
+Recall that the original KKT matrix is:
+
+```
+[ ∇²ₓₓL      Aᵀ ]
+[   A        0  ]
+```
+
+Scaling the KKT matrix for this problem gives:
+
+```
+[ D_x⁻¹ ∇²ₓₓL D_x⁻¹    D_x⁻¹ Aᵀ D_c ]
+[   D_c A D_x⁻¹             0       ]
+```
+
+With `D_x = I`, this reduces to:
+
+```
+[ ∇²ₓₓL      Aᵀ D_c ]
+[ D_c A        0   ]
+```
+
+Expanding `∇²ₓₓL` yields:
+
+```
+[ d_f ∇²ₓₓ f + Σ_i (D_c λ)_i ∇²ₓₓ c_i    Aᵀ D_c ]
+[            D_c A                         0   ]
+```
+
+where `D_c A` replaces `A` and `d_f ∇²ₓₓ f + Σ_i (D_c λ)_i ∇²ₓₓ c_i` replaces `∇²ₓₓ f + ∇²ₓₓ c` in the original KKT matrix.
+
+The algorithm is described in more detail in Section 3.8 of [^2].
+
 ## Works cited
 
 [^1]: Nocedal, J. and Wright, S. "Numerical Optimization", 2nd. ed., Ch. 19. Springer, 2006.

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -465,29 +465,29 @@ The Hessian of the scaled Lagrangian with respect to `x` is:
 Recall that the original KKT matrix is:
 
 ```
-[∇²ₓₓL  Aᵀ]
-[  A    0 ]
+  [∇²ₓₓL  Aᵀ]
+  [  A    0 ]
 ```
 
 Scaling the KKT matrix for this problem gives:
 
 ```
-[D_x⁻¹ ∇²ₓₓL D_x⁻¹  D_x⁻¹ Aᵀ D_c]
-[   D_c A D_x⁻¹          0      ]
+  [D_x⁻¹ ∇²ₓₓL D_x⁻¹  D_x⁻¹ Aᵀ D_c]
+  [   D_c A D_x⁻¹          0      ]
 ```
 
 With `D_x = I`, this reduces to:
 
 ```
-[∇²ₓₓL  Aᵀ D_c]
-[D_c A    0   ]
+  [∇²ₓₓL  Aᵀ D_c]
+  [D_c A    0   ]
 ```
 
 Expanding `∇²ₓₓL` yields:
 
 ```
-[d_f ∇²ₓₓf + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ    Aᵀ D_c]
-[            D_c A                   0   ]
+  [d_f ∇²ₓₓf + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ    Aᵀ D_c]
+  [            D_c A                   0   ]
 ```
 
 where `D_c A` replaces `A` and `d_f ∇²ₓₓf + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ` replaces `∇²ₓₓf + ∇²ₓₓc` in the original KKT matrix.

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -443,7 +443,7 @@ Section 6 of [^3] describes how to check for local infeasibility.
 
 ## Problem scaling
 
-Sleipnir scales the cost and constraints to improve numerical stability. The objective and each constraint are scaled so that the largest gradient component at the starting point is at most `g_max`. For an initial point `x₀`, define
+Sleipnir scales the cost and constraints to improve numerical stability. The cost and each constraint are scaled so that the largest gradient component at the starting point is at most `g_max`. For an initial point `x₀`, define
 
 ```
   d_f    = min(1, g_max / ‖∇f(x₀)‖_∞)
@@ -459,40 +459,40 @@ where `D_c = diag(d_c)` and `A = ∂c/∂x` is the constraint Jacobian. The scal
 The Hessian of the scaled Lagrangian with respect to `x` is:
 
 ```
-  ∇²ₓₓL(x, λ) = d_f ∇²ₓₓ f(x) + Σ_i (D_c λ)_i ∇²ₓₓ c_i(x)
+  ∇²ₓₓL(x, λ) = d_f ∇²ₓₓf(x) + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ(x)
 ```
 
 Recall that the original KKT matrix is:
 
 ```
-[ ∇²ₓₓL      Aᵀ ]
-[   A        0  ]
+[∇²ₓₓL  Aᵀ]
+[  A    0 ]
 ```
 
 Scaling the KKT matrix for this problem gives:
 
 ```
-[ D_x⁻¹ ∇²ₓₓL D_x⁻¹    D_x⁻¹ Aᵀ D_c ]
-[   D_c A D_x⁻¹             0       ]
+[D_x⁻¹ ∇²ₓₓL D_x⁻¹  D_x⁻¹ Aᵀ D_c]
+[   D_c A D_x⁻¹          0      ]
 ```
 
 With `D_x = I`, this reduces to:
 
 ```
-[ ∇²ₓₓL      Aᵀ D_c ]
-[ D_c A        0   ]
+[∇²ₓₓL  Aᵀ D_c]
+[D_c A    0   ]
 ```
 
 Expanding `∇²ₓₓL` yields:
 
 ```
-[ d_f ∇²ₓₓ f + Σ_i (D_c λ)_i ∇²ₓₓ c_i    Aᵀ D_c ]
-[            D_c A                         0   ]
+[d_f ∇²ₓₓf + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ    Aᵀ D_c]
+[            D_c A                   0   ]
 ```
 
-where `D_c A` replaces `A` and `d_f ∇²ₓₓ f + Σ_i (D_c λ)_i ∇²ₓₓ c_i` replaces `∇²ₓₓ f + ∇²ₓₓ c` in the original KKT matrix.
+where `D_c A` replaces `A` and `d_f ∇²ₓₓf + Σᵢ (D_c λ)ᵢ ∇²ₓₓcᵢ` replaces `∇²ₓₓf + ∇²ₓₓc` in the original KKT matrix.
 
-The algorithm is described in more detail in Section 3.8 of [^2].
+The algorithm is described in more detail in section 3.8 of [^2].
 
 ## Works cited
 

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -600,7 +600,7 @@ class Problem {
       // procedure is described in more detail in
       // docs/algorithms.md#problem-scaling.
       x_ad.set_value(x);
-      const auto scaling = ProblemScaling<Scalar>::interior_point(g, A_e, A_i);
+      const ProblemScaling<Scalar> scaling(g.value(), A_e.value(), A_i.value());
 
       InteriorPointMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -30,6 +30,7 @@
 #include "sleipnir/optimization/solver/options.hpp"
 #include "sleipnir/optimization/solver/sqp.hpp"
 #include "sleipnir/optimization/solver/util/bounds.hpp"
+#include "sleipnir/optimization/solver/util/problem_scaling.hpp"
 #include "sleipnir/util/empty.hpp"
 #include "sleipnir/util/print.hpp"
 #include "sleipnir/util/print_diagnostics.hpp"
@@ -673,7 +674,8 @@ class Problem {
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
             return d_c_i.asDiagonal() * A_i.value();
-          }};
+          },
+          ProblemScaling<Scalar>{d_f, d_c_e, d_c_i}};
 
       // Invoke interior-point method solver
       status =

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -31,6 +31,7 @@
 #include "sleipnir/optimization/solver/sqp.hpp"
 #include "sleipnir/optimization/solver/util/bounds.hpp"
 #include "sleipnir/optimization/solver/util/problem_scaling.hpp"
+#include "sleipnir/optimization/solver/util/sparse_inf_norms.hpp"
 #include "sleipnir/util/empty.hpp"
 #include "sleipnir/util/print.hpp"
 #include "sleipnir/util/print_diagnostics.hpp"
@@ -610,28 +611,13 @@ class Problem {
       const SparseMatrix A_e_0 = A_e.value();
       const SparseMatrix A_i_0 = A_i.value();
 
-      auto row_inf_norms = [](const SparseMatrix& A, int rows) {
-        DenseVector norms = DenseVector::Zero(rows);
-        for (int k = 0; k < A.outerSize(); ++k) {
-          for (typename SparseMatrix::InnerIterator it{A, k}; it; ++it) {
-            using std::abs;
-            norms[it.row()] = std::max(norms[it.row()], abs(it.value()));
-          }
-        }
-        return norms;
-      };
-
       const Scalar grad_f_inf = g_0.template lpNorm<Eigen::Infinity>();
       const Scalar d_f = std::min(Scalar(1), g_max / grad_f_inf);
 
       const DenseVector d_c_e =
-          (g_max / row_inf_norms(A_e_0, num_equality_constraints).array())
-              .min(Scalar(1))
-              .matrix();
+          (g_max / sparse_inf_norms(A_e_0).array()).min(Scalar(1)).matrix();
       const DenseVector d_c_i =
-          (g_max / row_inf_norms(A_i_0, num_inequality_constraints).array())
-              .min(Scalar(1))
-              .matrix();
+          (g_max / sparse_inf_norms(A_i_0).array()).min(Scalar(1)).matrix();
 
       InteriorPointMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -595,47 +595,84 @@ class Problem {
       project_onto_bounds(x, bounds);
 #endif
 
+      // Scale the objective and each constraint so the largest gradient
+      // component at the starting point is at most gₘₐₓ:
+      //
+      //   d_f    = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
+      //   d_c[j] = min(1, gₘₐₓ / ‖∇cⱼ(x₀)‖_∞)
+      //
+      // See §3.8 Automatic Scaling of the Problem Statement in [2].
+      constexpr Scalar g_max(100);
+
+      x_ad.set_value(x);
+      const DenseVector g_0 = g.value();
+      const SparseMatrix A_e_0 = A_e.value();
+      const SparseMatrix A_i_0 = A_i.value();
+
+      auto row_inf_norms = [](const SparseMatrix& A, int rows) {
+        DenseVector norms = DenseVector::Zero(rows);
+        for (int k = 0; k < A.outerSize(); ++k) {
+          for (typename SparseMatrix::InnerIterator it{A, k}; it; ++it) {
+            using std::abs;
+            norms[it.row()] = std::max(norms[it.row()], abs(it.value()));
+          }
+        }
+        return norms;
+      };
+
+      const Scalar grad_f_inf = g_0.template lpNorm<Eigen::Infinity>();
+      const Scalar d_f = std::min(Scalar(1), g_max / grad_f_inf);
+
+      const DenseVector d_c_e =
+          (g_max / row_inf_norms(A_e_0, num_equality_constraints).array())
+              .min(Scalar(1))
+              .matrix();
+      const DenseVector d_c_i =
+          (g_max / row_inf_norms(A_i_0, num_inequality_constraints).array())
+              .min(Scalar(1))
+              .matrix();
+
       InteriorPointMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,
           num_equality_constraints,
           num_inequality_constraints,
           [&](const DenseVector& x) -> Scalar {
             x_ad.set_value(x);
-            return f.value();
+            return d_f * f.value();
           },
           [&](const DenseVector& x) -> SparseVector {
             x_ad.set_value(x);
-            return g.value();
+            return d_f * g.value();
           },
           [&](const DenseVector& x, const DenseVector& y,
               const DenseVector& z) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(y);
-            z_ad.set_value(z);
-            return H_f.value() + H_c.value();
+            y_ad.set_value(d_c_e.cwiseProduct(y));
+            z_ad.set_value(d_c_i.cwiseProduct(z));
+            return d_f * H_f.value() + H_c.value();
           },
           [&](const DenseVector& x, const DenseVector& y,
               const DenseVector& z) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(y);
-            z_ad.set_value(z);
+            y_ad.set_value(d_c_e.cwiseProduct(y));
+            z_ad.set_value(d_c_i.cwiseProduct(z));
             return H_c.value();
           },
           [&](const DenseVector& x) -> DenseVector {
             x_ad.set_value(x);
-            return c_e_ad.value();
+            return d_c_e.cwiseProduct(c_e_ad.value());
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return A_e.value();
+            return d_c_e.asDiagonal() * A_e.value();
           },
           [&](const DenseVector& x) -> DenseVector {
             x_ad.set_value(x);
-            return c_i_ad.value();
+            return d_c_i.cwiseProduct(c_i_ad.value());
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return A_i.value();
+            return d_c_i.asDiagonal() * A_i.value();
           }};
 
       // Invoke interior-point method solver

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -31,7 +31,6 @@
 #include "sleipnir/optimization/solver/sqp.hpp"
 #include "sleipnir/optimization/solver/util/bounds.hpp"
 #include "sleipnir/optimization/solver/util/problem_scaling.hpp"
-#include "sleipnir/optimization/solver/util/sparse_inf_norms.hpp"
 #include "sleipnir/util/empty.hpp"
 #include "sleipnir/util/print.hpp"
 #include "sleipnir/util/print_diagnostics.hpp"
@@ -597,27 +596,11 @@ class Problem {
       project_onto_bounds(x, bounds);
 #endif
 
-      // Scale the objective and each constraint so the largest gradient
-      // component at the starting point is at most gₘₐₓ:
-      //
-      //   d_f    = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
-      //   d_c[j] = min(1, gₘₐₓ / ‖∇cⱼ(x₀)‖_∞)
-      //
-      // See §3.8 Automatic Scaling of the Problem Statement in [2].
-      constexpr Scalar g_max(100);
-
+      // Automatically scale the objective and constraints. The problem scaling
+      // procedure is described in more detail in
+      // docs/algorithms.md#problem-scaling.
       x_ad.set_value(x);
-      const DenseVector g_0 = g.value();
-      const SparseMatrix A_e_0 = A_e.value();
-      const SparseMatrix A_i_0 = A_i.value();
-
-      const Scalar grad_f_inf = g_0.template lpNorm<Eigen::Infinity>();
-      const Scalar d_f = std::min(Scalar(1), g_max / grad_f_inf);
-
-      const DenseVector d_c_e =
-          (g_max / sparse_inf_norms(A_e_0).array()).min(Scalar(1)).matrix();
-      const DenseVector d_c_i =
-          (g_max / sparse_inf_norms(A_i_0).array()).min(Scalar(1)).matrix();
+      const auto scaling = ProblemScaling<Scalar>::interior_point(g, A_e, A_i);
 
       InteriorPointMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,
@@ -625,43 +608,43 @@ class Problem {
           num_inequality_constraints,
           [&](const DenseVector& x) -> Scalar {
             x_ad.set_value(x);
-            return d_f * f.value();
+            return scaling.f * f.value();
           },
           [&](const DenseVector& x) -> SparseVector {
             x_ad.set_value(x);
-            return d_f * g.value();
+            return scaling.f * g.value();
           },
           [&](const DenseVector& x, const DenseVector& y,
               const DenseVector& z) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(d_c_e.cwiseProduct(y));
-            z_ad.set_value(d_c_i.cwiseProduct(z));
-            return d_f * H_f.value() + H_c.value();
+            y_ad.set_value(scaling.c_e.cwiseProduct(y));
+            z_ad.set_value(scaling.c_i.cwiseProduct(z));
+            return scaling.f * H_f.value() + H_c.value();
           },
           [&](const DenseVector& x, const DenseVector& y,
               const DenseVector& z) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(d_c_e.cwiseProduct(y));
-            z_ad.set_value(d_c_i.cwiseProduct(z));
+            y_ad.set_value(scaling.c_e.cwiseProduct(y));
+            z_ad.set_value(scaling.c_i.cwiseProduct(z));
             return H_c.value();
           },
           [&](const DenseVector& x) -> DenseVector {
             x_ad.set_value(x);
-            return d_c_e.cwiseProduct(c_e_ad.value());
+            return scaling.c_e.cwiseProduct(c_e_ad.value());
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return d_c_e.asDiagonal() * A_e.value();
+            return scaling.c_e.asDiagonal() * A_e.value();
           },
           [&](const DenseVector& x) -> DenseVector {
             x_ad.set_value(x);
-            return d_c_i.cwiseProduct(c_i_ad.value());
+            return scaling.c_i.cwiseProduct(c_i_ad.value());
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return d_c_i.asDiagonal() * A_i.value();
+            return scaling.c_i.asDiagonal() * A_i.value();
           },
-          ProblemScaling<Scalar>{d_f, d_c_e, d_c_i}};
+          scaling};
 
       // Invoke interior-point method solver
       status =

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -376,20 +376,26 @@ class Problem {
       }
 #endif
 
+      // Automatically scale the cost. The problem scaling procedure is
+      // described in more detail in docs/algorithms.md#problem-scaling.
+      x_ad.set_value(x);
+      const ProblemScaling<Scalar> scaling{g.value()};
+
       NewtonMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,
           [&](const DenseVector& x) -> Scalar {
             x_ad.set_value(x);
-            return f.value();
+            return scaling.f * f.value();
           },
           [&](const DenseVector& x) -> SparseVector {
             x_ad.set_value(x);
-            return g.value();
+            return scaling.f * g.value();
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return H.value();
-          }};
+            return scaling.f * H.value();
+          },
+          scaling};
 
       // Invoke Newton solver
       status =
@@ -464,35 +470,42 @@ class Problem {
       }
 #endif
 
+      // Automatically scale the cost and constraints. The problem scaling
+      // procedure is described in more detail in
+      // docs/algorithms.md#problem-scaling.
+      x_ad.set_value(x);
+      const ProblemScaling<Scalar> scaling{g.value(), A_e.value()};
+
       SQPMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,
           num_equality_constraints,
           [&](const DenseVector& x) -> Scalar {
             x_ad.set_value(x);
-            return f.value();
+            return scaling.f * f.value();
           },
           [&](const DenseVector& x) -> SparseVector {
             x_ad.set_value(x);
-            return g.value();
+            return scaling.f * g.value();
           },
           [&](const DenseVector& x, const DenseVector& y) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(y);
-            return H_f.value() + H_c.value();
+            y_ad.set_value(scaling.c_e.cwiseProduct(y));
+            return scaling.f * H_f.value() + H_c.value();
           },
           [&](const DenseVector& x, const DenseVector& y) -> SparseMatrix {
             x_ad.set_value(x);
-            y_ad.set_value(y);
+            y_ad.set_value(scaling.c_e.cwiseProduct(y));
             return H_c.value();
           },
           [&](const DenseVector& x) -> DenseVector {
             x_ad.set_value(x);
-            return c_e_ad.value();
+            return scaling.c_e.cwiseProduct(c_e_ad.value());
           },
           [&](const DenseVector& x) -> SparseMatrix {
             x_ad.set_value(x);
-            return A_e.value();
-          }};
+            return scaling.c_e.asDiagonal() * A_e.value();
+          },
+          scaling};
 
       // Invoke SQP solver
       status = sqp<Scalar>(matrix_callbacks, iteration_callbacks, options, x);

--- a/include/sleipnir/optimization/problem.hpp
+++ b/include/sleipnir/optimization/problem.hpp
@@ -596,11 +596,11 @@ class Problem {
       project_onto_bounds(x, bounds);
 #endif
 
-      // Automatically scale the objective and constraints. The problem scaling
+      // Automatically scale the cost and constraints. The problem scaling
       // procedure is described in more detail in
       // docs/algorithms.md#problem-scaling.
       x_ad.set_value(x);
-      const ProblemScaling<Scalar> scaling(g.value(), A_e.value(), A_i.value());
+      const ProblemScaling<Scalar> scaling{g.value(), A_e.value(), A_i.value()};
 
       InteriorPointMatrixCallbacks<Scalar> matrix_callbacks{
           num_decision_variables,

--- a/include/sleipnir/optimization/solver/interior_point.hpp
+++ b/include/sleipnir/optimization/solver/interior_point.hpp
@@ -76,7 +76,7 @@ ExitStatus interior_point(
   DenseVector y = DenseVector::Zero(matrix_callbacks.num_equality_constraints);
   DenseVector z =
       DenseVector::Ones(matrix_callbacks.num_inequality_constraints);
-  Scalar μ(0.1);
+  Scalar μ = Scalar(0.1) * matrix_callbacks.scaling.f;
 
   return interior_point(matrix_callbacks, iteration_callbacks, options, false,
 #ifdef SLEIPNIR_ENABLE_BOUND_PROJECTION
@@ -231,7 +231,8 @@ ExitStatus interior_point(
       [&](const DenseVector& x) -> SparseMatrix {
         ScopedProfiler prof{A_i_prof};
         return matrix_callbacks.A_i(x);
-      }};
+      },
+      matrix_callbacks.scaling};
 #else
   const auto& matrices = matrix_callbacks;
 #endif
@@ -290,7 +291,8 @@ ExitStatus interior_point(
   int iterations = 0;
 
   // Barrier parameter minimum
-  const Scalar μ_min = Scalar(options.tolerance) / Scalar(10);
+  const Scalar μ_min =
+      matrices.scaling.f * Scalar(options.tolerance) / Scalar(10);
 
   // Fraction-to-the-boundary rule scale factor minimum
   constexpr Scalar τ_min(0.99);
@@ -346,8 +348,8 @@ ExitStatus interior_point(
   int full_step_rejected_counter = 0;
 
   // Error
-  Scalar E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
-      g, A_e, c_e, A_i, c_i, s, y, z, Scalar(0));
+  Scalar E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+      matrices.scaling, g, A_e, c_e, A_i, c_i, s, y, z, Scalar(0));
 
   setup_prof.stop();
 
@@ -559,9 +561,9 @@ ExitStatus interior_point(
                   step_acceptable ? IterationType::ACCEPTED_SOC
                                   : IterationType::REJECTED_SOC,
                   soc_profiler.current_duration(),
-                  kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
-                      g, A_e, trial_c_e, A_i, trial_c_i, trial_s, trial_y,
-                      trial_z, Scalar(0)),
+                  unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+                      matrices.scaling, g, A_e, trial_c_e, A_i, trial_c_i,
+                      trial_s, trial_y, trial_z, Scalar(0)),
                   trial_f,
                   trial_c_e.template lpNorm<1>() +
                       (trial_c_i - trial_s).template lpNorm<1>(),
@@ -771,8 +773,8 @@ ExitStatus interior_point(
     H = matrices.H(x, y, z);
 
     // Update the error
-    E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
-        g, A_e, c_e, A_i, c_i, s, y, z, Scalar(0));
+    E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+        matrices.scaling, g, A_e, c_e, A_i, c_i, s, y, z, Scalar(0));
 
     // Update the barrier parameter if necessary
     if (E_0 > Scalar(options.tolerance)) {

--- a/include/sleipnir/optimization/solver/interior_point_matrix_callbacks.hpp
+++ b/include/sleipnir/optimization/solver/interior_point_matrix_callbacks.hpp
@@ -246,7 +246,7 @@ struct InteriorPointMatrixCallbacks {
 
   /// Automatic problem scaling factors. Used to scale the cost, constraints,
   /// and tolerance inside the interior-point solver.
-  ProblemScaling<Scalar> scaling{};
+  ProblemScaling<Scalar> scaling;
 };
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/interior_point_matrix_callbacks.hpp
+++ b/include/sleipnir/optimization/solver/interior_point_matrix_callbacks.hpp
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 
+#include "sleipnir/optimization/solver/util/problem_scaling.hpp"
+
 namespace slp {
 
 /// Matrix callbacks for the interior-point method solver.
@@ -241,6 +243,10 @@ struct InteriorPointMatrixCallbacks {
   ///   </tr>
   /// </table>
   std::function<SparseMatrix(const DenseVector& x)> A_i;
+
+  /// Automatic problem scaling factors. Used to scale the cost, constraints,
+  /// and tolerance inside the interior-point solver.
+  ProblemScaling<Scalar> scaling{};
 };
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/newton.hpp
+++ b/include/sleipnir/optimization/solver/newton.hpp
@@ -102,7 +102,8 @@ ExitStatus newton(
       [&](const DenseVector& x) -> SparseMatrix {
         ScopedProfiler prof{H_prof};
         return matrix_callbacks.H(x);
-      }};
+      },
+      matrix_callbacks.scaling};
 #else
   const auto& matrices = matrix_callbacks;
 #endif
@@ -139,7 +140,8 @@ ExitStatus newton(
   constexpr Scalar α_min(1e-20);
 
   // Error
-  Scalar E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(g);
+  Scalar E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+      matrices.scaling, g);
 
   setup_prof.stop();
 
@@ -253,7 +255,8 @@ ExitStatus newton(
     H = matrices.H(x);
 
     // Update the error
-    E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(g);
+    E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+        matrices.scaling, g);
 
     inner_iter_profiler.stop();
 

--- a/include/sleipnir/optimization/solver/newton_matrix_callbacks.hpp
+++ b/include/sleipnir/optimization/solver/newton_matrix_callbacks.hpp
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 
+#include "sleipnir/optimization/solver/util/problem_scaling.hpp"
+
 namespace slp {
 
 /// Matrix callbacks for the Newton's method solver.
@@ -90,6 +92,10 @@ struct NewtonMatrixCallbacks {
   ///   </tr>
   /// </table>
   std::function<SparseMatrix(const DenseVector& x)> H;
+
+  /// Automatic problem scaling factors. Used to scale the cost and tolerance
+  /// inside the Newton solver.
+  ProblemScaling<Scalar> scaling;
 };
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/sqp.hpp
+++ b/include/sleipnir/optimization/solver/sqp.hpp
@@ -175,7 +175,8 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
       [&](const DenseVector& x) -> SparseMatrix {
         ScopedProfiler prof{A_e_prof};
         return matrix_callbacks.A_e(x);
-      }};
+      },
+      matrix_callbacks.scaling};
 #else
   const auto& matrices = matrix_callbacks;
 #endif
@@ -235,7 +236,8 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
   int full_step_rejected_counter = 0;
 
   // Error
-  Scalar E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(g, A_e, c_e, y);
+  Scalar E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+      matrices.scaling, g, A_e, c_e, y);
 
   setup_prof.stop();
 
@@ -551,7 +553,8 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
     H = matrices.H(x, y);
 
     // Update the error
-    E_0 = kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(g, A_e, c_e, y);
+    E_0 = unscaled_kkt_error<Scalar, KKTErrorType::INF_NORM_SCALED>(
+        matrices.scaling, g, A_e, c_e, y);
 
     inner_iter_profiler.stop();
 

--- a/include/sleipnir/optimization/solver/sqp_matrix_callbacks.hpp
+++ b/include/sleipnir/optimization/solver/sqp_matrix_callbacks.hpp
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 
+#include "sleipnir/optimization/solver/util/problem_scaling.hpp"
+
 namespace slp {
 
 /// Matrix callbacks for the Sequential Quadratic Programming (SQP) solver.
@@ -175,6 +177,10 @@ struct SQPMatrixCallbacks {
   ///   </tr>
   /// </table>
   std::function<SparseMatrix(const DenseVector& x)> A_e;
+
+  /// Automatic problem scaling factors. Used to scale the cost, constraints,
+  /// and tolerance inside the SQP solver.
+  ProblemScaling<Scalar> scaling;
 };
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -287,7 +287,8 @@ ExitStatus feasibility_restoration(
         SparseMatrix A_i_p{2 * num_eq, x_p.rows()};
         A_i_p.setFromSortedTriplets(triplets.begin(), triplets.end());
         return A_i_p;
-      }};
+      },
+      ProblemScaling<Scalar>{}};
 
   auto status = interior_point<Scalar>(fr_matrix_callbacks, iteration_callbacks,
                                        options, true,
@@ -400,6 +401,15 @@ ExitStatus feasibility_restoration(
 
   Scalar fr_μ = std::max({μ, c_e.template lpNorm<Eigen::Infinity>(),
                           (c_i - s).template lpNorm<Eigen::Infinity>()});
+
+  // Inherit the parent problem's scaling for the constraints, and use no
+  // scaling for the objective function since it has changed. The new rows
+  // introduced are not scaled.
+  DenseVector fr_d_c_i{c_i.rows() + 2 * num_eq + 2 * num_ineq};
+  fr_d_c_i << matrices.scaling.c_i,
+      DenseVector::Ones(2 * num_eq + 2 * num_ineq);
+  const ProblemScaling<Scalar> fr_scaling{Scalar(1), matrices.scaling.c_e,
+                                          fr_d_c_i};
 
   InteriorPointMatrixCallbacks<Scalar> fr_matrix_callbacks{
       static_cast<int>(fr_x.rows()),
@@ -562,7 +572,8 @@ ExitStatus feasibility_restoration(
         SparseMatrix A_i_p{2 * num_eq + 3 * num_ineq, x_p.rows()};
         A_i_p.setFromSortedTriplets(triplets.begin(), triplets.end());
         return A_i_p;
-      }};
+      },
+      fr_scaling};
 
   auto status = interior_point<Scalar>(fr_matrix_callbacks, iteration_callbacks,
                                        options, true,

--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -169,6 +169,12 @@ ExitStatus feasibility_restoration(
 
   Scalar fr_μ = std::max(μ, c_e.template lpNorm<Eigen::Infinity>());
 
+  // Inherit the parent problem's scaling for the constraints, and use no
+  // scaling for the cost function since it has changed. The new rows introduced
+  // are not scaled.
+  const ProblemScaling<Scalar> fr_scaling{Scalar(1), matrices.scaling.c_e,
+                                          DenseVector::Ones(2 * num_eq)};
+
   InteriorPointMatrixCallbacks<Scalar> fr_matrix_callbacks{
       static_cast<int>(fr_x.rows()),
       static_cast<int>(fr_y.rows()),
@@ -288,7 +294,7 @@ ExitStatus feasibility_restoration(
         A_i_p.setFromSortedTriplets(triplets.begin(), triplets.end());
         return A_i_p;
       },
-      ProblemScaling<Scalar>{}};
+      fr_scaling};
 
   auto status = interior_point<Scalar>(fr_matrix_callbacks, iteration_callbacks,
                                        options, true,

--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -403,8 +403,8 @@ ExitStatus feasibility_restoration(
                           (c_i - s).template lpNorm<Eigen::Infinity>()});
 
   // Inherit the parent problem's scaling for the constraints, and use no
-  // scaling for the objective function since it has changed. The new rows
-  // introduced are not scaled.
+  // scaling for the cost function since it has changed. The new rows introduced
+  // are not scaled.
   DenseVector fr_d_c_i{c_i.rows() + 2 * num_eq + 2 * num_ineq};
   fr_d_c_i << matrices.scaling.c_i,
       DenseVector::Ones(2 * num_eq + 2 * num_ineq);

--- a/include/sleipnir/optimization/solver/util/kkt_error.hpp
+++ b/include/sleipnir/optimization/solver/util/kkt_error.hpp
@@ -158,17 +158,13 @@ Scalar kkt_error(const Eigen::Vector<Scalar, Eigen::Dynamic>& g,
 /// @param scaling The problem scaling factors.
 /// @param g Gradient of the scaled cost function d_f·∇f.
 /// @param A_e The problem's scaled equality constraint Jacobian D_cₑ·Aₑ(x)
-/// evaluated at the
-///     current iterate.
+/// evaluated at the current iterate.
 /// @param c_e The problem's scaled equality constraints D_cₑ(x) evaluated at
-/// the current
-///     iterate.
+/// the current iterate.
 /// @param A_i The problem's scaled inequality constraint Jacobian D_cᵢ·(x)
-/// evaluated at
-///     the current iterate.
+/// evaluated at the current iterate.
 /// @param c_i The problem's scaled inequality constraints D_cᵢ·cᵢ(x) evaluated
-/// at the
-///     current iterate.
+/// at the current iterate.
 /// @param s Scaled inequality constraint slack variables.
 /// @param y Scaled equality constraint dual variables.
 /// @param z Scaled inequality constraint dual variables.

--- a/include/sleipnir/optimization/solver/util/kkt_error.hpp
+++ b/include/sleipnir/optimization/solver/util/kkt_error.hpp
@@ -178,9 +178,9 @@ Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
 /// @param scaling The problem scaling factors.
 /// @param g Gradient of the scaled cost function d_f·∇f.
 /// @param A_e The problem's scaled equality constraint Jacobian D_cₑ·Aₑ(x)
-/// evaluated at the current iterate.
+///     evaluated at the current iterate.
 /// @param c_e The problem's scaled equality constraints D_cₑ·cₑ(x) evaluated
-/// at the current iterate.
+///     at the current iterate.
 /// @param y Scaled equality constraint dual variables.
 template <typename Scalar, KKTErrorType T>
 Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
@@ -214,13 +214,13 @@ Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
 /// @param scaling The problem scaling factors.
 /// @param g Gradient of the scaled cost function d_f·∇f.
 /// @param A_e The problem's scaled equality constraint Jacobian D_cₑ·Aₑ(x)
-/// evaluated at the current iterate.
-/// @param c_e The problem's scaled equality constraints D_cₑ(x) evaluated at
-/// the current iterate.
-/// @param A_i The problem's scaled inequality constraint Jacobian D_cᵢ·(x)
-/// evaluated at the current iterate.
+///     evaluated at the current iterate.
+/// @param c_e The problem's scaled equality constraints D_cₑ·cₑ(x) evaluated at
+///     the current iterate.
+/// @param A_i The problem's scaled inequality constraint Jacobian D_cᵢ·Aᵢ(x)
+///     evaluated at the current iterate.
 /// @param c_i The problem's scaled inequality constraints D_cᵢ·cᵢ(x) evaluated
-/// at the current iterate.
+///     at the current iterate.
 /// @param s Scaled inequality constraint slack variables.
 /// @param y Scaled equality constraint dual variables.
 /// @param z Scaled inequality constraint dual variables.

--- a/include/sleipnir/optimization/solver/util/kkt_error.hpp
+++ b/include/sleipnir/optimization/solver/util/kkt_error.hpp
@@ -151,7 +151,63 @@ Scalar kkt_error(const Eigen::Vector<Scalar, Eigen::Dynamic>& g,
   }
 }
 
-/// Returns the interior-point KKT error of the unscaled problem.
+/// Returns the unscaled KKT error for Newton's method.
+///
+/// @tparam Scalar Scalar type.
+/// @tparam T The type of KKT error to compute.
+/// @param scaling The problem scaling factors.
+/// @param g Gradient of the scaled cost function d_f·∇f.
+template <typename Scalar, KKTErrorType T>
+Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& g) {
+  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+
+  if (scaling.is_identity()) {
+    return kkt_error<Scalar, T>(g);
+  }
+
+  const DenseVector g_unscaled = (Scalar(1) / scaling.f) * g;
+
+  return kkt_error<Scalar, T>(g_unscaled);
+}
+
+/// Returns the unscaled KKT error for Sequential Quadratic Programming.
+///
+/// @tparam Scalar Scalar type.
+/// @tparam T The type of KKT error to compute.
+/// @param scaling The problem scaling factors.
+/// @param g Gradient of the scaled cost function d_f·∇f.
+/// @param A_e The problem's scaled equality constraint Jacobian D_cₑ·Aₑ(x)
+/// evaluated at the current iterate.
+/// @param c_e The problem's scaled equality constraints D_cₑ·cₑ(x) evaluated
+/// at the current iterate.
+/// @param y Scaled equality constraint dual variables.
+template <typename Scalar, KKTErrorType T>
+Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& g,
+                          const Eigen::SparseMatrix<Scalar>& A_e,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& c_e,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& y) {
+  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+  using SparseMatrix = Eigen::SparseMatrix<Scalar>;
+
+  if (scaling.is_identity()) {
+    return kkt_error<Scalar, T>(g, A_e, c_e, y);
+  }
+
+  const Scalar inv_d_f = Scalar(1) / scaling.f;
+  const DenseVector inv_d_c_e = scaling.c_e.cwiseInverse();
+
+  const DenseVector g_unscaled = inv_d_f * g;
+  const SparseMatrix A_e_unscaled = inv_d_c_e.asDiagonal() * A_e;
+  const DenseVector c_e_unscaled = inv_d_c_e.cwiseProduct(c_e);
+  const DenseVector y_unscaled = scaling.c_e.cwiseProduct(y) * inv_d_f;
+
+  return kkt_error<Scalar, T>(g_unscaled, A_e_unscaled, c_e_unscaled,
+                              y_unscaled);
+}
+
+/// Returns the unscaled KKT error for the interior-point method.
 ///
 /// @tparam Scalar Scalar type.
 /// @tparam T The type of KKT error to compute.

--- a/include/sleipnir/optimization/solver/util/kkt_error.hpp
+++ b/include/sleipnir/optimization/solver/util/kkt_error.hpp
@@ -191,18 +191,19 @@ Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
   const DenseVector inv_d_c_e = scaling.c_e.cwiseInverse();
   const DenseVector inv_d_c_i = scaling.c_i.cwiseInverse();
 
-  const DenseVector g_o = inv_d_f * g;
-  const SparseMatrix A_e_o = inv_d_c_e.asDiagonal() * A_e;
-  const DenseVector c_e_o = inv_d_c_e.cwiseProduct(c_e);
-  const SparseMatrix A_i_o = inv_d_c_i.asDiagonal() * A_i;
-  const DenseVector c_i_o = inv_d_c_i.cwiseProduct(c_i);
-  const DenseVector s_o = inv_d_c_i.cwiseProduct(s);
-  const DenseVector y_o = scaling.c_e.cwiseProduct(y) * inv_d_f;
-  const DenseVector z_o = scaling.c_i.cwiseProduct(z) * inv_d_f;
-  const Scalar μ_o = inv_d_f * μ;
+  const DenseVector g_unscaled = inv_d_f * g;
+  const SparseMatrix A_e_unscaled = inv_d_c_e.asDiagonal() * A_e;
+  const DenseVector c_e_unscaled = inv_d_c_e.cwiseProduct(c_e);
+  const SparseMatrix A_i_unscaled = inv_d_c_i.asDiagonal() * A_i;
+  const DenseVector c_i_unscaled = inv_d_c_i.cwiseProduct(c_i);
+  const DenseVector s_unscaled = inv_d_c_i.cwiseProduct(s);
+  const DenseVector y_unscaled = scaling.c_e.cwiseProduct(y) * inv_d_f;
+  const DenseVector z_unscaled = scaling.c_i.cwiseProduct(z) * inv_d_f;
+  const Scalar μ_unscaled = inv_d_f * μ;
 
-  return kkt_error<Scalar, T>(g_o, A_e_o, c_e_o, A_i_o, c_i_o, s_o, y_o, z_o,
-                              μ_o);
+  return kkt_error<Scalar, T>(g_unscaled, A_e_unscaled, c_e_unscaled,
+                              A_i_unscaled, c_i_unscaled, s_unscaled,
+                              y_unscaled, z_unscaled, μ_unscaled);
 }
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/util/kkt_error.hpp
+++ b/include/sleipnir/optimization/solver/util/kkt_error.hpp
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 
+#include "sleipnir/optimization/solver/util/problem_scaling.hpp"
+
 // See docs/algorithms.md#Works_cited for citation definitions
 
 namespace slp {
@@ -147,6 +149,64 @@ Scalar kkt_error(const Eigen::Vector<Scalar, Eigen::Dynamic>& g,
            (S * z - μe).template lpNorm<1>() + c_e.template lpNorm<1>() +
            (c_i - s).template lpNorm<1>();
   }
+}
+
+/// Returns the interior-point KKT error of the unscaled problem.
+///
+/// @tparam Scalar Scalar type.
+/// @tparam T The type of KKT error to compute.
+/// @param scaling The problem scaling factors.
+/// @param g Gradient of the scaled cost function d_f·∇f.
+/// @param A_e The problem's scaled equality constraint Jacobian D_cₑ·Aₑ(x)
+/// evaluated at the
+///     current iterate.
+/// @param c_e The problem's scaled equality constraints D_cₑ(x) evaluated at
+/// the current
+///     iterate.
+/// @param A_i The problem's scaled inequality constraint Jacobian D_cᵢ·(x)
+/// evaluated at
+///     the current iterate.
+/// @param c_i The problem's scaled inequality constraints D_cᵢ·cᵢ(x) evaluated
+/// at the
+///     current iterate.
+/// @param s Scaled inequality constraint slack variables.
+/// @param y Scaled equality constraint dual variables.
+/// @param z Scaled inequality constraint dual variables.
+/// @param μ Scaled barrier parameter.
+template <typename Scalar, KKTErrorType T>
+Scalar unscaled_kkt_error(const ProblemScaling<Scalar>& scaling,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& g,
+                          const Eigen::SparseMatrix<Scalar>& A_e,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& c_e,
+                          const Eigen::SparseMatrix<Scalar>& A_i,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& c_i,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& s,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& y,
+                          const Eigen::Vector<Scalar, Eigen::Dynamic>& z,
+                          Scalar μ) {
+  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+  using SparseMatrix = Eigen::SparseMatrix<Scalar>;
+
+  if (scaling.is_identity()) {
+    return kkt_error<Scalar, T>(g, A_e, c_e, A_i, c_i, s, y, z, μ);
+  }
+
+  const Scalar inv_d_f = Scalar(1) / scaling.f;
+  const DenseVector inv_d_c_e = scaling.c_e.cwiseInverse();
+  const DenseVector inv_d_c_i = scaling.c_i.cwiseInverse();
+
+  const DenseVector g_o = inv_d_f * g;
+  const SparseMatrix A_e_o = inv_d_c_e.asDiagonal() * A_e;
+  const DenseVector c_e_o = inv_d_c_e.cwiseProduct(c_e);
+  const SparseMatrix A_i_o = inv_d_c_i.asDiagonal() * A_i;
+  const DenseVector c_i_o = inv_d_c_i.cwiseProduct(c_i);
+  const DenseVector s_o = inv_d_c_i.cwiseProduct(s);
+  const DenseVector y_o = scaling.c_e.cwiseProduct(y) * inv_d_f;
+  const DenseVector z_o = scaling.c_i.cwiseProduct(z) * inv_d_f;
+  const Scalar μ_o = inv_d_f * μ;
+
+  return kkt_error<Scalar, T>(g_o, A_e_o, c_e_o, A_i_o, c_i_o, s_o, y_o, z_o,
+                              μ_o);
 }
 
 }  // namespace slp

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -73,7 +73,7 @@ struct ProblemScaling {
   ///
   /// @param g Cost gradient ∇f, evaluated at the starting point.
   /// @param A_e Equality constraint Jacobian Aₑ, evaluated at the starting
-  ///    point.
+  ///     point.
   ProblemScaling(const DenseVector& g, const SparseMatrix& A_e) {
     constexpr Scalar g_max(100);
 
@@ -93,9 +93,9 @@ struct ProblemScaling {
   ///
   /// @param g Cost gradient ∇f, evaluated at the starting point.
   /// @param A_e Equality constraint Jacobian Aₑ, evaluated at the starting
-  ///    point.
+  ///     point.
   /// @param A_i Inequality constraint Jacobian Aᵢ, evaluated at the starting
-  ///    point.
+  ///     point.
   ProblemScaling(const DenseVector& g, const SparseMatrix& A_e,
                  const SparseMatrix& A_i) {
     constexpr Scalar g_max(100);

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) Sleipnir contributors
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace slp {
+
+/// Automatic problem scaling factors.
+///
+/// @tparam Scalar Scalar type.
+template <typename Scalar>
+struct ProblemScaling {
+  /// Type alias for dense vector.
+  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+
+  /// Objective scaling factor d_f.
+  Scalar f = Scalar(1);
+
+  /// Equality constraint scaling factors d_cₑ.
+  DenseVector c_e = DenseVector{};
+
+  /// Inequality constraint scaling factors d_cᵢ.
+  DenseVector c_i = DenseVector{};
+
+  /// Whether the problem scaling is identity.
+  ///
+  /// @return True if the problem scaling is identity.
+  bool is_identity() const {
+    return f == Scalar(1) && c_e.size() == 0 && c_i.size() == 0;
+  }
+};
+
+}  // namespace slp

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -45,6 +45,42 @@ struct ProblemScaling {
   ProblemScaling(Scalar f, const DenseVector& c_e, const DenseVector& c_i)
       : f{f}, c_e{c_e}, c_i{c_i} {}
 
+  /// Computes Newton problem scaling.
+  ///
+  /// Scales the cost so the largest gradient component at the starting point
+  /// is at most gₘₐₓ:
+  ///
+  ///   d_f = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
+  ///
+  /// See §3.8 Automatic Scaling of the Problem Statement in [2].
+  ///
+  /// @param g Cost gradient ∇f, evaluated at the starting point.
+  explicit ProblemScaling(const DenseVector& g) {
+    constexpr Scalar g_max(100);
+
+    f = std::min(Scalar(1), g_max / g.template lpNorm<Eigen::Infinity>());
+  }
+
+  /// Computes SQP problem scaling.
+  ///
+  /// Scales the cost and each equality constraint so the largest gradient
+  /// component at the starting point is at most gₘₐₓ:
+  ///
+  ///   d_f     = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
+  ///   d_cₑ[j] = min(1, gₘₐₓ / ‖∇cₑⱼ(x₀)‖_∞)
+  ///
+  /// See §3.8 Automatic Scaling of the Problem Statement in [2].
+  ///
+  /// @param g Cost gradient ∇f, evaluated at the starting point.
+  /// @param A_e Equality constraint Jacobian Aₑ, evaluated at the starting
+  ///    point.
+  ProblemScaling(const DenseVector& g, const SparseMatrix& A_e) {
+    constexpr Scalar g_max(100);
+
+    f = std::min(Scalar(1), g_max / g.template lpNorm<Eigen::Infinity>());
+    c_e = (g_max / sparse_inf_norms(A_e).array()).min(Scalar(1)).matrix();
+  }
+
   /// Computes interior-point problem scaling.
   ///
   /// Scales the cost and each constraint so the largest gradient

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -2,7 +2,14 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <Eigen/Core>
+#include <Eigen/SparseCore>
+
+#include "sleipnir/optimization/solver/util/sparse_inf_norms.hpp"
+
+// See docs/algorithms.md#Works_cited for citation definitions
 
 namespace slp {
 
@@ -18,10 +25,42 @@ struct ProblemScaling {
   Scalar f = Scalar(1);
 
   /// Equality constraint scaling factors d_cₑ.
-  DenseVector c_e = DenseVector{};
+  DenseVector c_e;
 
   /// Inequality constraint scaling factors d_cᵢ.
-  DenseVector c_i = DenseVector{};
+  DenseVector c_i;
+
+  /// Computes interior-point problem scaling.
+  ///
+  /// Scales the objective and each constraint so the largest gradient
+  /// component at the starting point is at most gₘₐₓ:
+  ///
+  ///   d_f    = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
+  ///   d_c[j] = min(1, gₘₐₓ / ‖∇cⱼ(x₀)‖_∞)
+  ///
+  /// See §3.8 Automatic Scaling of the Problem Statement in [2].
+  ///
+  /// @tparam Gradient Cost gradient autodiff type.
+  /// @tparam Jacobian Constraint Jacobian autodiff type.
+  /// @param g Cost gradient autodiff ∇f, evaluated at the starting point.
+  /// @param A_e Equality constraint Jacobian autodiff Aₑ, evaluated at the
+  ///            starting point.
+  /// @param A_i Inequality constraint Jacobian autodiff Aᵢ, evaluated at the
+  ///            starting point.
+  /// @return The interior-point problem scaling.
+  template <typename Gradient, typename Jacobian>
+  static ProblemScaling interior_point(Gradient& g, Jacobian& A_e,
+                                       Jacobian& A_i) {
+    constexpr Scalar g_max(100);
+
+    const DenseVector grad_f = g.value();
+    return ProblemScaling{
+        std::min(Scalar(1), g_max / grad_f.template lpNorm<Eigen::Infinity>()),
+        (g_max / sparse_inf_norms(A_e.value()).array()).min(Scalar(1)).matrix(),
+        (g_max / sparse_inf_norms(A_i.value()).array())
+            .min(Scalar(1))
+            .matrix()};
+  }
 
   /// Whether the problem scaling is identity.
   ///

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -47,7 +47,7 @@ struct ProblemScaling {
 
   /// Computes interior-point problem scaling.
   ///
-  /// Scales the objective and each constraint so the largest gradient
+  /// Scales the cost and each constraint so the largest gradient
   /// component at the starting point is at most gₘₐₓ:
   ///
   ///   d_f    = min(1, gₘₐₓ / ‖∇f(x₀)‖_∞)
@@ -57,9 +57,9 @@ struct ProblemScaling {
   ///
   /// @param g Cost gradient ∇f, evaluated at the starting point.
   /// @param A_e Equality constraint Jacobian Aₑ, evaluated at the starting
-  ///            point.
+  ///    point.
   /// @param A_i Inequality constraint Jacobian Aᵢ, evaluated at the starting
-  ///            point.
+  ///    point.
   ProblemScaling(const DenseVector& g, const SparseMatrix& A_e,
                  const SparseMatrix& A_i) {
     constexpr Scalar g_max(100);

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -20,6 +20,10 @@ template <typename Scalar>
 struct ProblemScaling {
   /// Type alias for dense vector.
   using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+  /// Type alias for sparse matrix.
+  using SparseMatrix = Eigen::SparseMatrix<Scalar>;
+  /// Type alias for sparse vector.
+  using SparseVector = Eigen::SparseVector<Scalar>;
 
   /// Cost scaling factor d_f.
   Scalar f = Scalar(1);
@@ -29,6 +33,17 @@ struct ProblemScaling {
 
   /// Inequality constraint scaling factors d_cᵢ.
   DenseVector c_i;
+
+  /// Constructs identity problem scaling.
+  ProblemScaling() = default;
+
+  /// Constructs problem scaling from explicit factors.
+  ///
+  /// @param f Cost scaling factor d_f.
+  /// @param c_e Equality constraint scaling factors d_cₑ.
+  /// @param c_i Inequality constraint scaling factors d_cᵢ.
+  ProblemScaling(Scalar f, const DenseVector& c_e, const DenseVector& c_i)
+      : f{f}, c_e{c_e}, c_i{c_i} {}
 
   /// Computes interior-point problem scaling.
   ///
@@ -40,26 +55,18 @@ struct ProblemScaling {
   ///
   /// See §3.8 Automatic Scaling of the Problem Statement in [2].
   ///
-  /// @tparam Gradient Cost gradient autodiff type.
-  /// @tparam Jacobian Constraint Jacobian autodiff type.
-  /// @param g Cost gradient autodiff ∇f, evaluated at the starting point.
-  /// @param A_e Equality constraint Jacobian autodiff Aₑ, evaluated at the
-  ///            starting point.
-  /// @param A_i Inequality constraint Jacobian autodiff Aᵢ, evaluated at the
-  ///            starting point.
-  /// @return The interior-point problem scaling.
-  template <typename Gradient, typename Jacobian>
-  static ProblemScaling interior_point(Gradient& g, Jacobian& A_e,
-                                       Jacobian& A_i) {
+  /// @param g Cost gradient ∇f, evaluated at the starting point.
+  /// @param A_e Equality constraint Jacobian Aₑ, evaluated at the starting
+  ///            point.
+  /// @param A_i Inequality constraint Jacobian Aᵢ, evaluated at the starting
+  ///            point.
+  ProblemScaling(const DenseVector& g, const SparseMatrix& A_e,
+                 const SparseMatrix& A_i) {
     constexpr Scalar g_max(100);
 
-    const DenseVector grad_f = g.value();
-    return ProblemScaling{
-        std::min(Scalar(1), g_max / grad_f.template lpNorm<Eigen::Infinity>()),
-        (g_max / sparse_inf_norms(A_e.value()).array()).min(Scalar(1)).matrix(),
-        (g_max / sparse_inf_norms(A_i.value()).array())
-            .min(Scalar(1))
-            .matrix()};
+    f = std::min(Scalar(1), g_max / g.template lpNorm<Eigen::Infinity>());
+    c_e = (g_max / sparse_inf_norms(A_e).array()).min(Scalar(1)).matrix();
+    c_i = (g_max / sparse_inf_norms(A_i).array()).min(Scalar(1)).matrix();
   }
 
   /// Whether the problem scaling is identity.

--- a/include/sleipnir/optimization/solver/util/problem_scaling.hpp
+++ b/include/sleipnir/optimization/solver/util/problem_scaling.hpp
@@ -14,7 +14,7 @@ struct ProblemScaling {
   /// Type alias for dense vector.
   using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
 
-  /// Objective scaling factor d_f.
+  /// Cost scaling factor d_f.
   Scalar f = Scalar(1);
 
   /// Equality constraint scaling factors d_cₑ.

--- a/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
+++ b/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
@@ -7,6 +7,8 @@
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 
+namespace slp {
+
 /// Computes the row-wise infinity norm of a sparse matrix.
 ///
 /// @param mat Sparse matrix.
@@ -28,3 +30,5 @@ auto sparse_inf_norms(const Eigen::SparseCompressedBase<Derived>& mat)
 
   return norms;
 }
+
+} // namespace slp

--- a/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
+++ b/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
@@ -31,4 +31,4 @@ auto sparse_inf_norms(const Eigen::SparseCompressedBase<Derived>& mat)
   return norms;
 }
 
-} // namespace slp
+}  // namespace slp

--- a/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
+++ b/include/sleipnir/optimization/solver/util/sparse_inf_norms.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) Sleipnir contributors
+
+#pragma once
+
+#include <algorithm>
+
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
+
+/// Computes the row-wise infinity norm of a sparse matrix.
+///
+/// @param mat Sparse matrix.
+/// @return A dense vector where each element is the infinity norm of the
+///         corresponding row of the sparse matrix.
+template <typename Derived>
+auto sparse_inf_norms(const Eigen::SparseCompressedBase<Derived>& mat)
+    -> Eigen::Vector<typename Derived::Scalar, Eigen::Dynamic> {
+  using Scalar = typename Derived::Scalar;
+  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
+
+  DenseVector norms = DenseVector::Zero(mat.rows());
+  for (int k = 0; k < mat.outerSize(); ++k) {
+    for (typename Derived::InnerIterator it{mat, k}; it; ++it) {
+      using std::abs;
+      norms[it.row()] = std::max(norms[it.row()], abs(it.value()));
+    }
+  }
+
+  return norms;
+}


### PR DESCRIPTION
Implements automatic problem scaling in the same form used in ipopt.pdf. My Choreo benches on the WIP motor model show a -17% median solve time decrease and significantly more solver robustness - failure rate is down to 3% from previous 30% (mostly failing on large low-dt problems and weak actuator problems). No visible change in scalability benches.

The core is in problem.hpp; most of the added code is to scale the tolerances correctly inside the IPM solver to comply with the user-specified tolerance. Tried to keep it simple but the architecture may need a bit of work.

We may want to gate this behind a flag; ipopt.pdf mentions that 
> While these strategies seem to work well in some instances, the overall performance on the considered test set became worse.

although I haven't seen the behavior in practice - there are a few test cases in my Choreo trajectories that take longer to solve but it's a pretty small set.

Closes #831 