### PR TITLE
Fix case where regularization parameter could get stuck at zero

### DIFF
--- a/include/sleipnir/optimization/solver/util/dense_regularized_ldlt.hpp
+++ b/include/sleipnir/optimization/solver/util/dense_regularized_ldlt.hpp
@@ -86,26 +86,27 @@ class DenseRegularizedLDLT {
         Inertia inertia{m_solver.vectorD()};
 
         if (inertia == ideal_inertia) {
-          // If the inertia is ideal, store δ and return
+          // If the inertia is ideal, report success
           m_prev_δ = δ;
           return *this;
         } else if (inertia.zero > 0) {
-          // If there's zero eigenvalues, increase δ and γ by an order of
-          // magnitude and try again
-          δ *= Scalar(10);
-          γ *= Scalar(10);
+          if (γ == Scalar(0)) {
+            // If there's zero eigenvalues and γ = 0, increase γ
+            γ = Scalar(1e-10);
+          } else {
+            // If there's zero eigenvalues and γ > 0, increase δ and γ
+            δ *= Scalar(10);
+            γ *= Scalar(10);
+          }
         } else if (inertia.negative > ideal_inertia.negative) {
-          // If there's too many negative eigenvalues, increase δ by an order of
-          // magnitude and try again
+          // If there's too many negative eigenvalues, increase δ
           δ *= Scalar(10);
         } else if (inertia.positive > ideal_inertia.positive) {
-          // If there's too many positive eigenvalues, increase γ by an order of
-          // magnitude and try again
+          // If there's too many positive eigenvalues, increase γ
           γ = γ == Scalar(0) ? Scalar(1e-10) : γ * Scalar(10);
         }
       } else {
-        // If the decomposition failed, increase δ and γ by an order of
-        // magnitude and try again
+        // If the decomposition failed, increase δ and γ
         δ *= Scalar(10);
         γ *= Scalar(10);
       }

--- a/include/sleipnir/optimization/solver/util/sparse_regularized_ldlt.hpp
+++ b/include/sleipnir/optimization/solver/util/sparse_regularized_ldlt.hpp
@@ -102,26 +102,27 @@ class SparseRegularizedLDLT {
         Inertia inertia{m_solver.vectorD()};
 
         if (inertia == ideal_inertia) {
-          // If the inertia is ideal, store δ and return
+          // If the inertia is ideal, report success
           m_prev_δ = δ;
           return *this;
         } else if (inertia.zero > 0) {
-          // If there's zero eigenvalues, increase δ and γ by an order of
-          // magnitude and try again
-          δ *= Scalar(10);
-          γ *= Scalar(10);
+          if (γ == Scalar(0)) {
+            // If there's zero eigenvalues and γ = 0, increase γ
+            γ = Scalar(1e-10);
+          } else {
+            // If there's zero eigenvalues and γ > 0, increase δ and γ
+            δ *= Scalar(10);
+            γ *= Scalar(10);
+          }
         } else if (inertia.negative > ideal_inertia.negative) {
-          // If there's too many negative eigenvalues, increase δ by an order of
-          // magnitude and try again
+          // If there's too many negative eigenvalues, increase δ
           δ *= Scalar(10);
         } else if (inertia.positive > ideal_inertia.positive) {
-          // If there's too many positive eigenvalues, increase γ by an order of
-          // magnitude and try again
+          // If there's too many positive eigenvalues, increase γ
           γ = γ == Scalar(0) ? Scalar(1e-10) : γ * Scalar(10);
         }
       } else {
-        // If the decomposition failed, increase δ and γ by an order of
-        // magnitude and try again
+        // If the decomposition failed, increase δ and γ
         δ *= Scalar(10);
         γ *= Scalar(10);
       }


### PR DESCRIPTION
It shouldn't happen in practice since it requires γ_min = 0 and a rank-deficient Jacobian. We only let γ_min = 0 in feasibility restoration, and feasibility restoration shouldn't have a rank-deficient Jacobian.