### PR TITLE
Improve feasibility restoration initialization

### DIFF
--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -166,6 +166,7 @@ ExitStatus feasibility_restoration(
 
   DenseVector fr_y = DenseVector::Zero(num_eq);
 
+  // Force the duals to start with perfect complementarity with the slacks
   DenseVector fr_z{2 * num_eq};
   fr_z << fr_μ * p_e_0.cwiseInverse(), fr_μ * n_e_0.cwiseInverse();
 
@@ -385,7 +386,6 @@ ExitStatus feasibility_restoration(
 
   Scalar fr_μ = std::max({μ, c_e.template lpNorm<Eigen::Infinity>(),
                           (c_i - s).template lpNorm<Eigen::Infinity>()});
-
   const Scalar ζ = sqrt(fr_μ);
 
   const auto& x_r = x;

--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -146,12 +146,14 @@ ExitStatus feasibility_restoration(
 
   constexpr Scalar ρ(1e3);
   const Scalar μ(options.tolerance / 10.0);
-  const Scalar ζ = sqrt(μ);
 
   const DenseVector c_e = matrices.c_e(x);
 
+  Scalar fr_μ = std::max(μ, c_e.template lpNorm<Eigen::Infinity>());
+  const Scalar ζ = sqrt(fr_μ);
+
   const auto& x_r = x;
-  const auto [p_e_0, n_e_0] = compute_p_n(c_e, ρ, μ);
+  const auto [p_e_0, n_e_0] = compute_p_n(c_e, ρ, fr_μ);
 
   // Dᵣ = diag(min(1, 1/xᵣ[i]²) for i in x.rows())
   const DiagonalMatrix D_r =
@@ -165,9 +167,7 @@ ExitStatus feasibility_restoration(
   DenseVector fr_y = DenseVector::Zero(num_eq);
 
   DenseVector fr_z{2 * num_eq};
-  fr_z << μ * p_e_0.cwiseInverse(), μ * n_e_0.cwiseInverse();
-
-  Scalar fr_μ = std::max(μ, c_e.template lpNorm<Eigen::Infinity>());
+  fr_z << fr_μ * p_e_0.cwiseInverse(), fr_μ * n_e_0.cwiseInverse();
 
   // Inherit the parent problem's scaling for the constraints, and use no
   // scaling for the cost function since it has changed. The new rows introduced
@@ -379,14 +379,18 @@ ExitStatus feasibility_restoration(
   const auto& num_ineq = matrices.num_inequality_constraints;
 
   constexpr Scalar ρ(1e3);
-  const Scalar ζ = sqrt(μ);
 
   const DenseVector c_e = matrices.c_e(x);
   const DenseVector c_i = matrices.c_i(x);
 
+  Scalar fr_μ = std::max({μ, c_e.template lpNorm<Eigen::Infinity>(),
+                          (c_i - s).template lpNorm<Eigen::Infinity>()});
+
+  const Scalar ζ = sqrt(fr_μ);
+
   const auto& x_r = x;
-  const auto [p_e_0, n_e_0] = compute_p_n(c_e, ρ, μ);
-  const auto [p_i_0, n_i_0] = compute_p_n((c_i - s).eval(), ρ, μ);
+  const auto [p_e_0, n_e_0] = compute_p_n(c_e, ρ, fr_μ);
+  const auto [p_i_0, n_i_0] = compute_p_n((c_i - s).eval(), ρ, fr_μ);
 
   // Dᵣ = diag(min(1, 1/xᵣ[i]²) for i in x.rows())
   const DiagonalMatrix D_r =
@@ -401,12 +405,11 @@ ExitStatus feasibility_restoration(
 
   DenseVector fr_y = DenseVector::Zero(c_e.rows());
 
+  // Force the duals to start with perfect complementarity with the slacks
   DenseVector fr_z{c_i.rows() + 2 * num_eq + 2 * num_ineq};
-  fr_z << z.cwiseMin(ρ), μ * p_e_0.cwiseInverse(), μ * n_e_0.cwiseInverse(),
-      μ * p_i_0.cwiseInverse(), μ * n_i_0.cwiseInverse();
-
-  Scalar fr_μ = std::max({μ, c_e.template lpNorm<Eigen::Infinity>(),
-                          (c_i - s).template lpNorm<Eigen::Infinity>()});
+  fr_z << fr_μ * s.cwiseInverse(), fr_μ * p_e_0.cwiseInverse(),
+      fr_μ * n_e_0.cwiseInverse(), fr_μ * p_i_0.cwiseInverse(),
+      fr_μ * n_i_0.cwiseInverse();
 
   // Inherit the parent problem's scaling for the constraints, and use no
   // scaling for the cost function since it has changed. The new rows introduced

--- a/python/test/optimization/cart_pole_ocp_test.py
+++ b/python/test/optimization/cart_pole_ocp_test.py
@@ -79,14 +79,7 @@ def test_cart_pole_ocp():
     assert problem.equality_constraint_type() == ExpressionType.NONLINEAR
     assert problem.inequality_constraint_type() == ExpressionType.LINEAR
 
-    if platform.system() == "Windows" and platform.machine() == "ARM64":
-        # FIXME: Fails on Windows aarch64 with "feasibility restoration failed"
-        assert (
-            problem.solve(diagnostics=True) == ExitStatus.FEASIBILITY_RESTORATION_FAILED
-        )
-        return
-    else:
-        assert problem.solve(diagnostics=True) == ExitStatus.SUCCESS
+    assert problem.solve(diagnostics=True) == ExitStatus.SUCCESS
 
     # Verify initial state
     assert X.value(0, 0) == pytest.approx(x_initial[0, 0], abs=1e-8)

--- a/python/test/optimization/cart_pole_ocp_test.py
+++ b/python/test/optimization/cart_pole_ocp_test.py
@@ -1,5 +1,4 @@
 import math
-import platform
 
 import numpy as np
 import pytest

--- a/test/src/optimization/cart_pole_ocp_test.cpp
+++ b/test/src/optimization/cart_pole_ocp_test.cpp
@@ -79,14 +79,7 @@ TEMPLATE_TEST_CASE("OCP - Cart-pole", "[OCP]", SCALAR_TYPES_UNDER_TEST) {
   CHECK(problem.equality_constraint_type() == slp::ExpressionType::NONLINEAR);
   CHECK(problem.inequality_constraint_type() == slp::ExpressionType::LINEAR);
 
-#if defined(_WIN32) && defined(__ARM_ARCH)
-  // FIXME: Fails on Windows aarch64 with "feasibility restoration failed"
-  REQUIRE(problem.solve({.diagnostics = true}) ==
-          slp::ExitStatus::FEASIBILITY_RESTORATION_FAILED);
-  return;
-#else
   REQUIRE(problem.solve({.diagnostics = true}) == slp::ExitStatus::SUCCESS);
-#endif
 
   // Verify initial state
   CHECK_THAT(X.value(0, 0), WithinAbs(x_initial[0], T(1e-8)));


### PR DESCRIPTION
Re-works the initialization of feasibility restoration:
- Switch to using the calculated FR barrier parameter for all initialization parameters. This is inline with ipopt.pdf.
- Modifies the dual slack initialization to use `z = μ ⋅ s⁻¹`, which forces the initial condition to meet the complementarity constraints. This is a divergence from ipopt.pdf, which suggests that `fr_z = min{ρ, z}`, but enforcing complementarity seems to produce significantly better results on ill-conditioned problems like G-FOLD, and doesn't show any performance regression on my Choreo benchmark set in terms of feasibility or speed, though no improvement either - this fix seems to help mostly with badly ill-conditioned problems. I don't entirely understand what IPOPT is doing here anyways - why should the new duals be directly related to the old cost function duals or ρ, and they don't explain it.