### PR TITLE
Improve second order corrections handling

### DIFF
--- a/include/sleipnir/optimization/solver/interior_point.hpp
+++ b/include/sleipnir/optimization/solver/interior_point.hpp
@@ -557,6 +557,8 @@ ExitStatus interior_point(
         Scalar α_z_soc = α_z;
         DenseVector c_e_soc = c_e;
 
+        Scalar soc_constraint_violation = next_constraint_violation;
+
         bool step_acceptable = false;
         for (int soc_iteration = 0; soc_iteration < 5 && !step_acceptable;
              ++soc_iteration) {
@@ -612,6 +614,16 @@ ExitStatus interior_point(
           trial_c_e = matrices.c_e(trial_x);
           trial_c_i = matrices.c_i(trial_x);
 
+          // Check whether filter accepts trial iterate
+          FilterEntry trial_entry{trial_f, trial_s, trial_c_e, trial_c_i, μ};
+          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+            step = soc_step;
+            α = α_soc;
+            α_z = α_z_soc;
+            step_acceptable = true;
+            break;
+          }
+
           // Constraint violation scale factor for second-order corrections
           constexpr Scalar κ_soc(0.99);
 
@@ -620,18 +632,11 @@ ExitStatus interior_point(
           next_constraint_violation =
               trial_c_e.template lpNorm<1>() +
               (trial_c_i - trial_s).template lpNorm<1>();
-          if (next_constraint_violation > κ_soc * prev_constraint_violation) {
+          if (next_constraint_violation > κ_soc * soc_constraint_violation) {
             break;
           }
 
-          // Check whether filter accepts trial iterate
-          FilterEntry trial_entry{trial_f, trial_s, trial_c_e, trial_c_i, μ};
-          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
-            step = soc_step;
-            α = α_soc;
-            α_z = α_z_soc;
-            step_acceptable = true;
-          }
+          soc_constraint_violation = next_constraint_violation;
         }
 
         if (step_acceptable) {

--- a/include/sleipnir/optimization/solver/sqp.hpp
+++ b/include/sleipnir/optimization/solver/sqp.hpp
@@ -383,6 +383,8 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
         Scalar α_soc = α;
         DenseVector c_e_soc = c_e;
 
+        Scalar soc_constraint_violation = next_constraint_violation;
+
         bool step_acceptable = false;
         for (int soc_iteration = 0; soc_iteration < 5 && !step_acceptable;
              ++soc_iteration) {
@@ -425,23 +427,26 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
           trial_f = matrices.f(trial_x);
           trial_c_e = matrices.c_e(trial_x);
 
+          // Check whether the filter accepts trial iterate
+          FilterEntry trial_entry{trial_f, trial_c_e};
+          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+            step = soc_step;
+            α = α_soc;
+            step_acceptable = true;
+            break;
+          }
+
           // Constraint violation scale factor for second-order corrections
           constexpr Scalar κ_soc(0.99);
 
           // If constraint violation hasn't been sufficiently reduced, stop
           // making second-order corrections
           next_constraint_violation = trial_c_e.template lpNorm<1>();
-          if (next_constraint_violation > κ_soc * prev_constraint_violation) {
+          if (next_constraint_violation > κ_soc * soc_constraint_violation) {
             break;
           }
 
-          // Check whether filter accepts trial iterate
-          FilterEntry trial_entry{trial_f, trial_c_e};
-          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
-            step = soc_step;
-            α = α_soc;
-            step_acceptable = true;
-          }
+          soc_constraint_violation = next_constraint_violation;
         }
 
         if (step_acceptable) {

--- a/python/test/optimization/cart_pole_ocp_test.py
+++ b/python/test/optimization/cart_pole_ocp_test.py
@@ -79,14 +79,7 @@ def test_cart_pole_ocp():
     assert problem.equality_constraint_type() == ExpressionType.NONLINEAR
     assert problem.inequality_constraint_type() == ExpressionType.LINEAR
 
-    if platform.system() == "Windows" and platform.machine() == "ARM64":
-        # FIXME: Fails on Windows aarch64 with "feasibility restoration failed"
-        assert (
-            problem.solve(diagnostics=True) == ExitStatus.FEASIBILITY_RESTORATION_FAILED
-        )
-        return
-    else:
-        assert problem.solve(diagnostics=True) == ExitStatus.SUCCESS
+    assert problem.solve(diagnostics=True) == ExitStatus.SUCCESS
 
     # Verify initial state
     assert X.value(0, 0) == pytest.approx(x_initial[0, 0], abs=1e-8)

--- a/python/test/optimization/cart_pole_ocp_test.py
+++ b/python/test/optimization/cart_pole_ocp_test.py
@@ -1,5 +1,4 @@
 import math
-import platform
 
 import numpy as np
 import pytest

--- a/test/src/optimization/cart_pole_ocp_test.cpp
+++ b/test/src/optimization/cart_pole_ocp_test.cpp
@@ -79,14 +79,7 @@ TEMPLATE_TEST_CASE("OCP - Cart-pole", "[OCP]", SCALAR_TYPES_UNDER_TEST) {
   CHECK(problem.equality_constraint_type() == slp::ExpressionType::NONLINEAR);
   CHECK(problem.inequality_constraint_type() == slp::ExpressionType::LINEAR);
 
-#if defined(_WIN32) && defined(__ARM_ARCH)
-  // FIXME: Fails on Windows aarch64 with "feasibility restoration failed"
-  REQUIRE(problem.solve({.diagnostics = true}) ==
-          slp::ExitStatus::FEASIBILITY_RESTORATION_FAILED);
-  return;
-#else
   REQUIRE(problem.solve({.diagnostics = true}) == slp::ExitStatus::SUCCESS);
-#endif
 
   // Verify initial state
   CHECK_THAT(X.value(0, 0), WithinAbs(x_initial[0], T(1e-8)));


### PR DESCRIPTION
When doing second order corrections, check if the filter accepts the new iterate before checking whether or not the constraint violation has decreased, and when iterating on a correction check the current constraint violation against the previous instead of the original. This brings the Sleipnir SOC procedure in-line with the one described in ipopt.pdf; benchmarks show 16% reduction in solve time on Choreo test set and no regressions in problem feasibility. 