### PR TITLE
Fix memory leak in non-pool allocation path

### DIFF
--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -779,6 +779,8 @@ constexpr void dec_ref_count(Expression<Scalar>* expr) {
         auto alloc = global_pool_allocator<Expression<Scalar>>();
         std::allocator_traits<decltype(alloc)>::deallocate(
             alloc, elem, sizeof(Expression<Scalar>));
+      } else {
+        operator delete(elem);
       }
     }
   }


### PR DESCRIPTION
I tested this locally by setting USE_POOL_ALLOCATOR to false and running asan on all the tests.