### PR TITLE
Fix in-place Variable matrix multiplication

### DIFF
--- a/include/sleipnir/autodiff/variable_block.hpp
+++ b/include/sleipnir/autodiff/variable_block.hpp
@@ -434,12 +434,13 @@ class VariableBlock : public SleipnirBase {
     slp_assert(cols() == rhs.rows() && cols() == rhs.cols());
 
     for (int i = 0; i < rows(); ++i) {
+      VariableMatrix lhs_old_row = row(i);
       for (int j = 0; j < rhs.cols(); ++j) {
         Variable sum{Scalar(0)};
         for (int k = 0; k < cols(); ++k) {
-          sum += (*this)(i, k) * rhs(k, j);
+          sum += lhs_old_row[k] * rhs[k, j];
         }
-        (*this)(i, j) = sum;
+        (*this)[i, j] = sum;
       }
     }
 

--- a/include/sleipnir/autodiff/variable_matrix.hpp
+++ b/include/sleipnir/autodiff/variable_matrix.hpp
@@ -640,10 +640,11 @@ class VariableMatrix : public SleipnirBase {
     slp_assert(cols() == rhs.rows() && cols() == rhs.cols());
 
     for (int i = 0; i < rows(); ++i) {
+      VariableMatrix lhs_old_row = row(i);
       for (int j = 0; j < rhs.cols(); ++j) {
         Variable sum{Scalar(0)};
         for (int k = 0; k < cols(); ++k) {
-          sum += (*this)[i, k] * rhs[k, j];
+          sum += lhs_old_row[k] * rhs[k, j];
         }
         (*this)[i, j] = sum;
       }


### PR DESCRIPTION
The algorithm progressively overwrites each row, so the old row needs to be cached for the sum operation.