### PR TITLE
Use gradient of log-barrier function in IPM iterate filter

### DIFF
--- a/include/sleipnir/optimization/solver/interior_point.hpp
+++ b/include/sleipnir/optimization/solver/interior_point.hpp
@@ -497,6 +497,11 @@ ExitStatus interior_point(
     α_z = fraction_to_the_boundary_rule<Scalar>(z, step.p_z, τ);
 
     const FilterEntry<Scalar> current_entry{f, s, c_e, c_i, μ};
+
+    // Compute the directional derivative of the IPM cost function along the
+    // search direction by
+    // ϕ_μ(x, s) = f(x) − μ∑ᵢ ln(sᵢ)
+    // D_ϕ = ∇ϕ_μ(x, s)ᵀ[pˣ pˢ] = ∇f(x)ᵀpˣ − μ∑ᵢ pᵢˢ/sᵢ
     const Scalar D_ϕ =
         g.transpose() * step.p_x - μ * s.cwiseInverse().dot(step.p_s);
 

--- a/include/sleipnir/optimization/solver/interior_point.hpp
+++ b/include/sleipnir/optimization/solver/interior_point.hpp
@@ -497,6 +497,8 @@ ExitStatus interior_point(
     α_z = fraction_to_the_boundary_rule<Scalar>(z, step.p_z, τ);
 
     const FilterEntry<Scalar> current_entry{f, s, c_e, c_i, μ};
+    const Scalar D_ϕ =
+        g.transpose() * step.p_x - μ * s.cwiseInverse().dot(step.p_s);
 
     // Loop until a step is accepted
     while (1) {
@@ -533,7 +535,7 @@ ExitStatus interior_point(
 
       // Check whether filter accepts trial iterate
       FilterEntry trial_entry{trial_f, trial_s, trial_c_e, trial_c_i, μ};
-      if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+      if (filter.try_add(current_entry, trial_entry, D_ϕ, α)) {
         // Accept step
         break;
       }
@@ -615,7 +617,7 @@ ExitStatus interior_point(
 
           // Check whether filter accepts trial iterate
           FilterEntry trial_entry{trial_f, trial_s, trial_c_e, trial_c_i, μ};
-          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+          if (filter.try_add(current_entry, trial_entry, D_ϕ, α)) {
             step = soc_step;
             α = α_soc;
             α_z = α_z_soc;
@@ -729,9 +731,11 @@ ExitStatus interior_point(
         // is accepted by the normal filter, stop feasibility restoration
         FilterEntry trial_entry{matrices.f(trial_x), trial_s, trial_c_e,
                                 trial_c_i, μ};
+        const Scalar D_ϕ_restoration = g.transpose() * (trial_x - x) -
+                                       μ * s.cwiseInverse().dot(trial_s - s);
         return trial_entry.constraint_violation <
                    Scalar(0.9) * initial_entry.constraint_violation &&
-               filter.try_add(initial_entry, trial_entry, trial_x - x, g, α);
+               filter.try_add(initial_entry, trial_entry, D_ϕ_restoration, α);
       });
       auto status =
           feasibility_restoration<Scalar>(matrices, callbacks, options,

--- a/include/sleipnir/optimization/solver/interior_point.hpp
+++ b/include/sleipnir/optimization/solver/interior_point.hpp
@@ -498,8 +498,9 @@ ExitStatus interior_point(
 
     const FilterEntry<Scalar> current_entry{f, s, c_e, c_i, μ};
 
-    // Compute the directional derivative of the IPM cost function along the
-    // search direction by
+    // Compute the directional derivative of the log-barrier function along the
+    // search direction.
+    //
     // ϕ_μ(x, s) = f(x) − μ∑ᵢ ln(sᵢ)
     // D_ϕ = ∇ϕ_μ(x, s)ᵀ[pˣ pˢ] = ∇f(x)ᵀpˣ − μ∑ᵢ pᵢˢ/sᵢ
     const Scalar D_ϕ =

--- a/include/sleipnir/optimization/solver/newton.hpp
+++ b/include/sleipnir/optimization/solver/newton.hpp
@@ -195,6 +195,7 @@ ExitStatus newton(
 
     constexpr Scalar α_max(1);
     Scalar α = α_max;
+    const Scalar D_ϕ = g.transpose() * p_x;
 
     // Loop until a step is accepted. If a step becomes acceptable, the loop
     // will exit early.
@@ -215,7 +216,7 @@ ExitStatus newton(
       }
 
       // Check whether filter accepts trial iterate
-      if (filter.try_add(FilterEntry{f}, FilterEntry{trial_f}, p_x, g, α)) {
+      if (filter.try_add(FilterEntry{f}, FilterEntry{trial_f}, D_ϕ, α)) {
         // Accept step
         break;
       }

--- a/include/sleipnir/optimization/solver/sqp.hpp
+++ b/include/sleipnir/optimization/solver/sqp.hpp
@@ -339,6 +339,7 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
     α = α_max;
 
     const FilterEntry<Scalar> current_entry{f, c_e};
+    const Scalar D_ϕ = g.transpose() * step.p_x;
 
     // Loop until a step is accepted
     while (1) {
@@ -363,7 +364,7 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
 
       // Check whether filter accepts trial iterate
       FilterEntry trial_entry{trial_f, trial_c_e};
-      if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+      if (filter.try_add(current_entry, trial_entry, D_ϕ, α)) {
         // Accept step
         break;
       }
@@ -428,7 +429,7 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
 
           // Check whether the filter accepts trial iterate
           FilterEntry trial_entry{trial_f, trial_c_e};
-          if (filter.try_add(current_entry, trial_entry, step.p_x, g, α)) {
+          if (filter.try_add(current_entry, trial_entry, D_ϕ, α)) {
             step = soc_step;
             α = α_soc;
             step_acceptable = true;
@@ -524,12 +525,13 @@ ExitStatus sqp(const SQPMatrixCallbacks<Scalar>& matrix_callbacks,
         DenseVector trial_c_e = matrices.c_e(trial_x);
 
         FilterEntry trial_entry{matrices.f(trial_x), trial_c_e};
+        const Scalar D_ϕ_restoration = g.transpose() * (trial_x - x);
 
         // If the current iterate sufficiently reduces constraint violation and
         // is accepted by the normal filter, stop feasibility restoration
         return trial_entry.constraint_violation <
                    Scalar(0.9) * initial_entry.constraint_violation &&
-               filter.try_add(initial_entry, trial_entry, trial_x - x, g, α);
+               filter.try_add(initial_entry, trial_entry, D_ϕ_restoration, α);
       });
       auto status = feasibility_restoration<Scalar>(matrices, callbacks,
                                                     options, x, y, iterations);

--- a/include/sleipnir/optimization/solver/util/filter.hpp
+++ b/include/sleipnir/optimization/solver/util/filter.hpp
@@ -6,7 +6,6 @@
 #include <cmath>
 
 #include <Eigen/Core>
-#include <Eigen/SparseCore>
 #include <gch/small_vector.hpp>
 
 // See docs/algorithms.md#Works_cited for citation definitions.
@@ -75,12 +74,6 @@ struct FilterEntry {
 template <typename Scalar>
 class Filter {
  public:
-  /// Type alias for dense vector.
-  using DenseVector = Eigen::Vector<Scalar, Eigen::Dynamic>;
-
-  /// Type alias for sparse vector.
-  using SparseVector = Eigen::SparseVector<Scalar>;
-
   /// The minimum constraint violation
   Scalar min_constraint_violation;
 
@@ -110,13 +103,11 @@ class Filter {
   ///
   /// @param current_entry The entry corresponding to the current iterate.
   /// @param trial_entry The entry corresponding to the trial iterate.
-  /// @param p_x Decision variable primal step.
-  /// @param g Cost function gradient.
+  /// @param D_ϕ Cost directional derivative along the search direction.
   /// @param α The step size (0, 1].
   /// @return True if the given entry is acceptable to the filter.
   bool try_add(const FilterEntry<Scalar>& current_entry,
-               const FilterEntry<Scalar>& trial_entry, const DenseVector& p_x,
-               const SparseVector& g, Scalar α) {
+               const FilterEntry<Scalar>& trial_entry, Scalar D_ϕ, Scalar α) {
     using std::isfinite;
     using std::pow;
 
@@ -126,19 +117,17 @@ class Filter {
       return false;
     }
 
-    Scalar g_p_x = g.transpose() * p_x;
-
     // Switching condition
     constexpr Scalar s_ϕ(2.3);
     constexpr Scalar s_θ(1.1);
     bool switching_condition =
-        g_p_x < Scalar(0) &&
-        α * pow(-g_p_x, s_ϕ) > pow(current_entry.constraint_violation, s_θ);
+        D_ϕ < Scalar(0) &&
+        α * pow(-D_ϕ, s_ϕ) > pow(current_entry.constraint_violation, s_θ);
 
     // Armijo condition
     constexpr Scalar η_ϕ(1e-8);
     bool armijo_condition =
-        trial_entry.cost <= current_entry.cost + η_ϕ * α * g_p_x;
+        trial_entry.cost <= current_entry.cost + η_ϕ * α * D_ϕ;
 
     // Sufficient decrease condition
     //


### PR DESCRIPTION
The IPM iterate filter was checking whether the step direction passed the filter using the gradient of the user-supplied cost function, instead of the gradient of the total IPM cost function which includes a barrier term. Checked against ipopt.pdf.