### PR TITLE
Fix incorrect results for Gradient and Hessian autodiff when using abs/max/min/pow

### DIFF
--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -432,6 +432,8 @@ ExpressionPtr<Scalar> sin(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
 ExpressionPtr<Scalar> sinh(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
+ExpressionPtr<Scalar> sign(const ExpressionPtr<Scalar>& x);
+template <typename Scalar>
 ExpressionPtr<Scalar> sqrt(const ExpressionPtr<Scalar>& x);
 
 /// Derived expression type for binary minus operator.
@@ -797,13 +799,7 @@ struct AbsExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_l(
       const ExpressionPtr<Scalar>& x,
       const ExpressionPtr<Scalar>&) const override {
-    if (x->val < Scalar(0)) {
-      return -this->adjoint_expr;
-    } else if (x->val > Scalar(0)) {
-      return this->adjoint_expr;
-    } else {
-      return constant_ptr(Scalar(0));
-    }
+    return this->adjoint_expr * sign(x);
   }
 };
 
@@ -1462,6 +1458,39 @@ ExpressionPtr<Scalar> log10(const ExpressionPtr<Scalar>& x) {
   return make_expression_ptr<Log10Expression<Scalar>>(x);
 }
 
+/// Derived expression type for is_positive().
+///
+/// @tparam Scalar Scalar type.
+template <typename Scalar>
+struct IsPositiveExpression final : Expression<Scalar> {
+  /// Constructs an unary expression (an operator with one argument).
+  ///
+  /// @param x Unary operator's operand.
+  explicit constexpr IsPositiveExpression(ExpressionPtr<Scalar> x)
+      : Expression<Scalar>{std::move(x)} {}
+
+  Scalar value(Scalar x, Scalar) const override {
+    return x > Scalar(0) ? Scalar(1) : Scalar(0);
+  }
+
+  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
+
+  std::string_view name() const override { return "is positive"; }
+};
+
+/// Returns one if x is positive and zero otherwise.
+///
+/// @tparam Scalar Scalar type.
+/// @param x The argument.
+template <typename Scalar>
+ExpressionPtr<Scalar> is_positive(const ExpressionPtr<Scalar>& x) {
+  if (x->type() == ExpressionType::CONSTANT) {
+    return constant_ptr(x->val > Scalar(0) ? Scalar(1) : Scalar(0));
+  }
+
+  return make_expression_ptr<IsPositiveExpression<Scalar>>(x);
+}
+
 /// Derived expression type for max().
 ///
 /// Returns the greater of a and b. If the values are equivalent, returns a.
@@ -1504,21 +1533,13 @@ struct MaxExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_l(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    if (a->val >= b->val) {
-      return this->adjoint_expr;
-    } else {
-      return constant_ptr(Scalar(0));
-    }
+    return this->adjoint_expr * (constant_ptr(Scalar(1)) - is_positive(b - a));
   }
 
   ExpressionPtr<Scalar> grad_expr_r(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    if (b->val > a->val) {
-      return this->adjoint_expr;
-    } else {
-      return constant_ptr(Scalar(0));
-    }
+    return this->adjoint_expr * is_positive(b - a);
   }
 };
 
@@ -1584,21 +1605,13 @@ struct MinExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_l(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    if (a->val <= b->val) {
-      return this->adjoint_expr;
-    } else {
-      return constant_ptr(Scalar(0));
-    }
+    return this->adjoint_expr * (constant_ptr(Scalar(1)) - is_positive(a - b));
   }
 
   ExpressionPtr<Scalar> grad_expr_r(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    if (b->val < a->val) {
-      return this->adjoint_expr;
-    } else {
-      return constant_ptr(Scalar(0));
-    }
+    return this->adjoint_expr * is_positive(a - b);
   }
 };
 
@@ -1675,12 +1688,11 @@ struct PowExpression final : Expression<Scalar> {
       const ExpressionPtr<Scalar>& base,
       const ExpressionPtr<Scalar>& power) const override {
     // Since x log(x) -> 0 as x -> 0
-    if (base->val == Scalar(0)) {
-      // Return zero
-      return base;
-    } else {
-      return this->adjoint_expr * pow(base, power) * log(base);
-    }
+    // We use the sign of base to avoid evaluating log(0) when base is zero.
+    auto nonzero = abs(sign(base));
+    auto safe_base = base + (constant_ptr(Scalar(1)) - nonzero);
+    return this->adjoint_expr * nonzero * pow(safe_base, power) *
+           log(safe_base);
   }
 };
 

--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -1523,6 +1523,7 @@ ExpressionPtr<Scalar> log10(const ExpressionPtr<Scalar>& x) {
 
   return make_expression_ptr<Log10Expression<Scalar>>(x);
 }
+
 /// Derived expression type for max().
 ///
 /// Returns the greater of a and b. If the values are equivalent, returns a.

--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -428,11 +428,11 @@ ExpressionPtr<Scalar> cbrt(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
 ExpressionPtr<Scalar> exp(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
+ExpressionPtr<Scalar> sign(const ExpressionPtr<Scalar>& x);
+template <typename Scalar>
 ExpressionPtr<Scalar> sin(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
 ExpressionPtr<Scalar> sinh(const ExpressionPtr<Scalar>& x);
-template <typename Scalar>
-ExpressionPtr<Scalar> sign(const ExpressionPtr<Scalar>& x);
 template <typename Scalar>
 ExpressionPtr<Scalar> sqrt(const ExpressionPtr<Scalar>& x);
 
@@ -1352,6 +1352,72 @@ ExpressionPtr<Scalar> hypot(const ExpressionPtr<Scalar>& x,
   return make_expression_ptr<HypotExpression<Scalar>>(x, y);
 }
 
+/// Derived expression type for is_nonnegative().
+///
+/// @tparam Scalar Scalar type.
+template <typename Scalar>
+struct IsNonnegativeExpression final : Expression<Scalar> {
+  /// Constructs an unary expression (an operator with one argument).
+  ///
+  /// @param x Unary operator's operand.
+  explicit constexpr IsNonnegativeExpression(ExpressionPtr<Scalar> x)
+      : Expression<Scalar>{std::move(x)} {}
+
+  Scalar value(Scalar x, Scalar) const override {
+    return x >= Scalar(0) ? Scalar(1) : Scalar(0);
+  }
+
+  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
+
+  std::string_view name() const override { return "is positive"; }
+};
+
+/// Returns one if x is nonnegative and zero otherwise.
+///
+/// @tparam Scalar Scalar type.
+/// @param x The argument.
+template <typename Scalar>
+ExpressionPtr<Scalar> is_nonnegative(const ExpressionPtr<Scalar>& x) {
+  if (x->type() == ExpressionType::CONSTANT) {
+    return constant_ptr(x->val >= Scalar(0) ? Scalar(1) : Scalar(0));
+  }
+
+  return make_expression_ptr<IsNonnegativeExpression<Scalar>>(x);
+}
+
+/// Derived expression type for is_positive().
+///
+/// @tparam Scalar Scalar type.
+template <typename Scalar>
+struct IsPositiveExpression final : Expression<Scalar> {
+  /// Constructs an unary expression (an operator with one argument).
+  ///
+  /// @param x Unary operator's operand.
+  explicit constexpr IsPositiveExpression(ExpressionPtr<Scalar> x)
+      : Expression<Scalar>{std::move(x)} {}
+
+  Scalar value(Scalar x, Scalar) const override {
+    return x > Scalar(0) ? Scalar(1) : Scalar(0);
+  }
+
+  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
+
+  std::string_view name() const override { return "is positive"; }
+};
+
+/// Returns one if x is positive and zero otherwise.
+///
+/// @tparam Scalar Scalar type.
+/// @param x The argument.
+template <typename Scalar>
+ExpressionPtr<Scalar> is_positive(const ExpressionPtr<Scalar>& x) {
+  if (x->type() == ExpressionType::CONSTANT) {
+    return constant_ptr(x->val > Scalar(0) ? Scalar(1) : Scalar(0));
+  }
+
+  return make_expression_ptr<IsPositiveExpression<Scalar>>(x);
+}
+
 /// Derived expression type for log().
 ///
 /// @tparam Scalar Scalar type.
@@ -1457,40 +1523,6 @@ ExpressionPtr<Scalar> log10(const ExpressionPtr<Scalar>& x) {
 
   return make_expression_ptr<Log10Expression<Scalar>>(x);
 }
-
-/// Derived expression type for is_positive().
-///
-/// @tparam Scalar Scalar type.
-template <typename Scalar>
-struct IsPositiveExpression final : Expression<Scalar> {
-  /// Constructs an unary expression (an operator with one argument).
-  ///
-  /// @param x Unary operator's operand.
-  explicit constexpr IsPositiveExpression(ExpressionPtr<Scalar> x)
-      : Expression<Scalar>{std::move(x)} {}
-
-  Scalar value(Scalar x, Scalar) const override {
-    return x > Scalar(0) ? Scalar(1) : Scalar(0);
-  }
-
-  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
-
-  std::string_view name() const override { return "is positive"; }
-};
-
-/// Returns one if x is positive and zero otherwise.
-///
-/// @tparam Scalar Scalar type.
-/// @param x The argument.
-template <typename Scalar>
-ExpressionPtr<Scalar> is_positive(const ExpressionPtr<Scalar>& x) {
-  if (x->type() == ExpressionType::CONSTANT) {
-    return constant_ptr(x->val > Scalar(0) ? Scalar(1) : Scalar(0));
-  }
-
-  return make_expression_ptr<IsPositiveExpression<Scalar>>(x);
-}
-
 /// Derived expression type for max().
 ///
 /// Returns the greater of a and b. If the values are equivalent, returns a.
@@ -1525,12 +1557,18 @@ struct MaxExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_l(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    return this->adjoint_expr * (constant_ptr(Scalar(1)) - is_positive(b - a));
+    // adjoint * (a >= b)
+    // adjoint * (a - b >= 0)
+    return this->adjoint_expr * is_nonnegative(a - b);
   }
 
   ExpressionPtr<Scalar> grad_expr_r(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
+    // adjoint * !(a >= b)
+    // adjoint * (a < b)
+    // adjoint * (b > a)
+    // adjoint * (b - a > 0)
     return this->adjoint_expr * is_positive(b - a);
   }
 };
@@ -1589,12 +1627,18 @@ struct MinExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_l(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
-    return this->adjoint_expr * (constant_ptr(Scalar(1)) - is_positive(a - b));
+    // adjoint * (a <= b)
+    // adjoint * (b >= a)
+    // adjoint * (b - a >= 0)
+    return this->adjoint_expr * is_nonnegative(b - a);
   }
 
   ExpressionPtr<Scalar> grad_expr_r(
       const ExpressionPtr<Scalar>& a,
       const ExpressionPtr<Scalar>& b) const override {
+    // adjoint * !(a <= b)
+    // adjoint * (a > b)
+    // adjoint * (a - b > 0)
     return this->adjoint_expr * is_positive(a - b);
   }
 };

--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -1385,39 +1385,6 @@ ExpressionPtr<Scalar> is_nonnegative(const ExpressionPtr<Scalar>& x) {
   return make_expression_ptr<IsNonnegativeExpression<Scalar>>(x);
 }
 
-/// Derived expression type for is_nonzero().
-///
-/// @tparam Scalar Scalar type.
-template <typename Scalar>
-struct IsNonzeroExpression final : Expression<Scalar> {
-  /// Constructs an unary expression (an operator with one argument).
-  ///
-  /// @param x Unary operator's operand.
-  explicit constexpr IsNonzeroExpression(ExpressionPtr<Scalar> x)
-      : Expression<Scalar>{std::move(x)} {}
-
-  Scalar value(Scalar x, Scalar) const override {
-    return x != Scalar(0) ? Scalar(1) : Scalar(0);
-  }
-
-  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
-
-  std::string_view name() const override { return "is nonzero"; }
-};
-
-/// Returns one if x is nonzero and zero otherwise.
-///
-/// @tparam Scalar Scalar type.
-/// @param x The argument.
-template <typename Scalar>
-ExpressionPtr<Scalar> is_nonzero(const ExpressionPtr<Scalar>& x) {
-  if (x->type() == ExpressionType::CONSTANT) {
-    return constant_ptr(x->val != Scalar(0) ? Scalar(1) : Scalar(0));
-  }
-
-  return make_expression_ptr<IsNonzeroExpression<Scalar>>(x);
-}
-
 /// Derived expression type for is_positive().
 ///
 /// @tparam Scalar Scalar type.
@@ -1731,9 +1698,7 @@ struct PowExpression final : Expression<Scalar> {
     using std::log;
     using std::pow;
 
-    // Since x log(x) -> 0 as x -> 0
-    return base == Scalar(0) ? Scalar(0)
-                             : this->adjoint * pow(base, power) * log(base);
+    return this->adjoint * pow(base, power) * log(base);
   }
 
   ExpressionPtr<Scalar> grad_expr_l(
@@ -1746,12 +1711,7 @@ struct PowExpression final : Expression<Scalar> {
   ExpressionPtr<Scalar> grad_expr_r(
       const ExpressionPtr<Scalar>& base,
       const ExpressionPtr<Scalar>& power) const override {
-    // Since x log(x) -> 0 as x -> 0
-    // We check whether base is nonzero to avoid evaluating log(0).
-    auto nonzero = is_nonzero(base);
-    auto safe_base = base + (constant_ptr(Scalar(1)) - nonzero);
-    return this->adjoint_expr * nonzero * pow(safe_base, power) *
-           log(safe_base);
+    return this->adjoint_expr * pow(base, power) * log(base);
   }
 };
 

--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -1369,7 +1369,7 @@ struct IsNonnegativeExpression final : Expression<Scalar> {
 
   ExpressionType type() const override { return ExpressionType::NONLINEAR; }
 
-  std::string_view name() const override { return "is positive"; }
+  std::string_view name() const override { return "is nonnegative"; }
 };
 
 /// Returns one if x is nonnegative and zero otherwise.
@@ -1383,6 +1383,39 @@ ExpressionPtr<Scalar> is_nonnegative(const ExpressionPtr<Scalar>& x) {
   }
 
   return make_expression_ptr<IsNonnegativeExpression<Scalar>>(x);
+}
+
+/// Derived expression type for is_nonzero().
+///
+/// @tparam Scalar Scalar type.
+template <typename Scalar>
+struct IsNonzeroExpression final : Expression<Scalar> {
+  /// Constructs an unary expression (an operator with one argument).
+  ///
+  /// @param x Unary operator's operand.
+  explicit constexpr IsNonzeroExpression(ExpressionPtr<Scalar> x)
+      : Expression<Scalar>{std::move(x)} {}
+
+  Scalar value(Scalar x, Scalar) const override {
+    return x != Scalar(0) ? Scalar(1) : Scalar(0);
+  }
+
+  ExpressionType type() const override { return ExpressionType::NONLINEAR; }
+
+  std::string_view name() const override { return "is nonzero"; }
+};
+
+/// Returns one if x is nonzero and zero otherwise.
+///
+/// @tparam Scalar Scalar type.
+/// @param x The argument.
+template <typename Scalar>
+ExpressionPtr<Scalar> is_nonzero(const ExpressionPtr<Scalar>& x) {
+  if (x->type() == ExpressionType::CONSTANT) {
+    return constant_ptr(x->val != Scalar(0) ? Scalar(1) : Scalar(0));
+  }
+
+  return make_expression_ptr<IsNonzeroExpression<Scalar>>(x);
 }
 
 /// Derived expression type for is_positive().
@@ -1714,8 +1747,8 @@ struct PowExpression final : Expression<Scalar> {
       const ExpressionPtr<Scalar>& base,
       const ExpressionPtr<Scalar>& power) const override {
     // Since x log(x) -> 0 as x -> 0
-    // We use the sign of base to avoid evaluating log(0) when base is zero.
-    auto nonzero = abs(sign(base));
+    // We check whether base is nonzero to avoid evaluating log(0).
+    auto nonzero = is_nonzero(base);
     auto safe_base = base + (constant_ptr(Scalar(1)) - nonzero);
     return this->adjoint_expr * nonzero * pow(safe_base, power) *
            log(safe_base);

--- a/python/test/autodiff/gradient_test.py
+++ b/python/test/autodiff/gradient_test.py
@@ -363,6 +363,20 @@ def test_abs():
     assert g.get().value()[0, 0] == 0.0
     assert g.value()[0, 0] == 0.0
 
+    f = autodiff.abs(x * x - 4.0)
+    g = Gradient(f, x)
+    symbolic_g = g.get()
+
+    x.set_value(3.0)
+    assert symbolic_g.value()[0, 0] == 6.0
+    assert g.value()[0, 0] == 6.0
+    assert g.get().value()[0, 0] == 6.0
+
+    x.set_value(1.0)
+    assert symbolic_g.value()[0, 0] == -2.0
+    assert g.value()[0, 0] == -2.0
+    assert g.get().value()[0, 0] == -2.0
+
 
 def test_atan2():
     x = Variable()

--- a/python/test/autodiff/hessian_test.py
+++ b/python/test/autodiff/hessian_test.py
@@ -209,6 +209,71 @@ def test_nested_powers():
     assert H[0, 0] == pytest.approx(12 * x0 * x0, abs=1e-12)
 
 
+def test_max_and_min():
+    input = VariableMatrix(2)
+    expected_y = np.array([[0.0, 0.0], [0.0, 2.0]])
+    expected_x = np.array([[2.0, 0.0], [0.0, 0.0]])
+
+    def check(f, x0, y0, x1, y1):
+        hessian = Hessian(f, input)
+        symbolic_H = hessian.get()
+
+        input[0].set_value(x0)
+        input[1].set_value(y0)
+        np.testing.assert_array_equal(symbolic_H.value(), expected_y)
+        np.testing.assert_array_equal(hessian.value().todense(), expected_y)
+
+        input[0].set_value(x1)
+        input[1].set_value(y1)
+        np.testing.assert_array_equal(symbolic_H.value(), expected_x)
+        np.testing.assert_array_equal(hessian.value().todense(), expected_x)
+
+        input[0].set_value(2.0)
+        input[1].set_value(2.0)
+        np.testing.assert_array_equal(symbolic_H.value(), expected_x)
+        np.testing.assert_array_equal(hessian.value().todense(), expected_x)
+
+    x_squared = input[0] * input[0]
+    y_squared = input[1] * input[1]
+    check(autodiff.max(x_squared, y_squared), 1.0, 2.0, 3.0, 2.0)
+    check(autodiff.min(x_squared, y_squared), 2.0, 1.0, 2.0, 3.0)
+
+
+def test_pow():
+    input = VariableMatrix(2)
+    f = autodiff.pow(input[0] + 1.0, input[1])
+    hessian = Hessian(f, input)
+
+    # Construct the symbolic Hessian while the base's cached value is zero.
+    symbolic_H = hessian.get()
+
+    input[0].set_value(2.0)
+    input[1].set_value(3.0)
+    mixed = 9.0 * (1.0 + 3.0 * math.log(3.0))
+    expected = np.array([[18.0, mixed], [mixed, 27.0 * math.log(3.0) ** 2]])
+    np.testing.assert_allclose(symbolic_H.value(), expected, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(
+        hessian.value().todense(), expected, rtol=0.0, atol=1e-12
+    )
+
+    input[0].set_value(3.0)
+    input[1].set_value(2.0)
+    mixed = 4.0 * (1.0 + 2.0 * math.log(4.0))
+    expected = np.array([[2.0, mixed], [mixed, 16.0 * math.log(4.0) ** 2]])
+    np.testing.assert_allclose(symbolic_H.value(), expected, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(
+        hessian.value().todense(), expected, rtol=0.0, atol=1e-12
+    )
+
+    input[0].set_value(-1.0)
+    input[1].set_value(2.0)
+    expected = np.array([[2.0, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(symbolic_H.value(), expected, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(
+        hessian.value().todense(), expected, rtol=0.0, atol=1e-12
+    )
+
+
 def test_rosenbrock():
     # z = (1 − x)² + 100(y − x²)²
     #   = 100(−x² + y)² + (−x + 1)²

--- a/python/test/autodiff/hessian_test.py
+++ b/python/test/autodiff/hessian_test.py
@@ -244,7 +244,6 @@ def test_pow():
     f = autodiff.pow(input[0] + 1.0, input[1])
     hessian = Hessian(f, input)
 
-    # Construct the symbolic Hessian while the base's cached value is zero.
     symbolic_H = hessian.get()
 
     input[0].set_value(2.0)
@@ -260,14 +259,6 @@ def test_pow():
     input[1].set_value(2.0)
     mixed = 4.0 * (1.0 + 2.0 * math.log(4.0))
     expected = np.array([[2.0, mixed], [mixed, 16.0 * math.log(4.0) ** 2]])
-    np.testing.assert_allclose(symbolic_H.value(), expected, rtol=0.0, atol=1e-12)
-    np.testing.assert_allclose(
-        hessian.value().todense(), expected, rtol=0.0, atol=1e-12
-    )
-
-    input[0].set_value(-1.0)
-    input[1].set_value(2.0)
-    expected = np.array([[2.0, 0.0], [0.0, 0.0]])
     np.testing.assert_allclose(symbolic_H.value(), expected, rtol=0.0, atol=1e-12)
     np.testing.assert_allclose(
         hessian.value().todense(), expected, rtol=0.0, atol=1e-12

--- a/test/src/autodiff/gradient_test.cpp
+++ b/test/src/autodiff/gradient_test.cpp
@@ -450,6 +450,20 @@ TEMPLATE_TEST_CASE("Gradient - abs()", "[Gradient]", SCALAR_TYPES_UNDER_TEST) {
   CHECK(slp::abs(x).value() == abs(x.value()));
   CHECK(g.get().value().coeff(0) == T(0));
   CHECK(g.value().coeff(0) == T(0));
+
+  auto f = slp::abs(x * x - T(4));
+  g = slp::Gradient{f, x};
+  auto symbolic_g = g.get();
+
+  x.set_value(T(3));
+  CHECK(symbolic_g.value(0) == T(6));
+  CHECK(g.value().coeff(0) == T(6));
+  CHECK(g.get().value(0) == T(6));
+
+  x.set_value(T(1));
+  CHECK(symbolic_g.value(0) == T(-2));
+  CHECK(g.value().coeff(0) == T(-2));
+  CHECK(g.get().value(0) == T(-2));
 }
 
 TEMPLATE_TEST_CASE("Gradient - atan2()", "[Gradient]",

--- a/test/src/autodiff/hessian_test.cpp
+++ b/test/src/autodiff/hessian_test.cpp
@@ -359,12 +359,6 @@ TEMPLATE_TEST_CASE("Hessian - pow()", "[Hessian]", SCALAR_TYPES_UNDER_TEST) {
                                     {mixed, T(16) * pow(log(T(4)), T(2))}};
   CHECK_THAT(symbolic_H.value(), MatrixWithinAbs(expected, T(1e-12)));
   CHECK_THAT(hessian.value().toDense(), MatrixWithinAbs(expected, T(1e-12)));
-
-  input[0].set_value(T(-1));
-  input[1].set_value(T(2));
-  expected = Eigen::Matrix<T, 2, 2>{{T(2), T(0)}, {T(0), T(0)}};
-  CHECK_THAT(symbolic_H.value(), MatrixWithinAbs(expected, T(1e-12)));
-  CHECK_THAT(hessian.value().toDense(), MatrixWithinAbs(expected, T(1e-12)));
 }
 
 TEMPLATE_TEST_CASE("Hessian - Rosenbrock", "[Hessian]",

--- a/test/src/autodiff/hessian_test.cpp
+++ b/test/src/autodiff/hessian_test.cpp
@@ -293,6 +293,80 @@ TEMPLATE_TEST_CASE("Hessian - Nested powers", "[Hessian]",
   CHECK_THAT(H(0, 0), WithinAbs(T(12) * x0 * x0, T(1e-12)));
 }
 
+TEMPLATE_TEST_CASE("Hessian - max() and min()", "[Hessian]",
+                   SCALAR_TYPES_UNDER_TEST) {
+  using T = TestType;
+
+  slp::scope_exit exit{
+      [] { CHECK(slp::global_pool_resource().blocks_in_use() == 0u); }};
+
+  slp::VariableMatrix<T> input{2};
+  Eigen::Matrix<T, 2, 2> expected_y{{T(0), T(0)}, {T(0), T(2)}};
+  Eigen::Matrix<T, 2, 2> expected_x{{T(2), T(0)}, {T(0), T(0)}};
+
+  auto check = [&](slp::Variable<T> f, T x0, T y0, T x1, T y1) {
+    slp::Hessian hessian{f, input};
+    auto symbolic_H = hessian.get();
+
+    input[0].set_value(x0);
+    input[1].set_value(y0);
+    CHECK(symbolic_H.value() == expected_y);
+    CHECK(hessian.value().toDense() == expected_y);
+
+    input[0].set_value(x1);
+    input[1].set_value(y1);
+    CHECK(symbolic_H.value() == expected_x);
+    CHECK(hessian.value().toDense() == expected_x);
+
+    input[0].set_value(T(2));
+    input[1].set_value(T(2));
+    CHECK(symbolic_H.value() == expected_x);
+    CHECK(hessian.value().toDense() == expected_x);
+  };
+
+  auto x_squared = input[0] * input[0];
+  auto y_squared = input[1] * input[1];
+  check(slp::max(x_squared, y_squared), T(1), T(2), T(3), T(2));
+  check(slp::min(x_squared, y_squared), T(2), T(1), T(2), T(3));
+}
+
+TEMPLATE_TEST_CASE("Hessian - pow()", "[Hessian]", SCALAR_TYPES_UNDER_TEST) {
+  using T = TestType;
+  using std::log;
+  using std::pow;
+
+  slp::scope_exit exit{
+      [] { CHECK(slp::global_pool_resource().blocks_in_use() == 0u); }};
+
+  slp::VariableMatrix<T> input{2};
+  auto f = slp::pow(input[0] + T(1), input[1]);
+  slp::Hessian hessian{f, input};
+
+  auto symbolic_H = hessian.get();
+
+  input[0].set_value(T(2));
+  input[1].set_value(T(3));
+  T mixed = T(9) * (T(1) + T(3) * log(T(3)));
+  Eigen::Matrix<T, 2, 2> expected{{T(18), mixed},
+                                  {mixed, T(27) * pow(log(T(3)), T(2))}};
+  CHECK_THAT(symbolic_H.value(), MatrixWithinAbs(expected, T(1e-12)));
+  CHECK_THAT(hessian.value().toDense(), MatrixWithinAbs(expected, T(1e-12)));
+
+  input[0].set_value(T(3));
+  input[1].set_value(T(2));
+  mixed = T(4) * (T(1) + T(2) * log(T(4)));
+  expected = Eigen::Matrix<T, 2, 2>{{T(2), mixed},
+                                    {mixed, T(16) * pow(log(T(4)), T(2))}};
+  CHECK_THAT(symbolic_H.value(), MatrixWithinAbs(expected, T(1e-12)));
+  CHECK_THAT(hessian.value().toDense(), MatrixWithinAbs(expected, T(1e-12)));
+
+  input[0].set_value(T(-1));
+  input[1].set_value(T(2));
+  expected = Eigen::Matrix<T, 2, 2>{{T(2), T(0)}, {T(0), T(0)}};
+  CHECK_THAT(symbolic_H.value(), MatrixWithinAbs(expected, T(1e-12)));
+  CHECK_THAT(hessian.value().toDense(), MatrixWithinAbs(expected, T(1e-12)));
+}
+
 TEMPLATE_TEST_CASE("Hessian - Rosenbrock", "[Hessian]",
                    SCALAR_TYPES_UNDER_TEST) {
   // z = (1 − x)² + 100(y − x²)²


### PR DESCRIPTION
I think the if statements were problematic because they were operating once on the value and returning (essentially reading a cached value without checking the value will be constant), so I lifted all of them up into the expression layer, which fixes issues with `Gradient.get().value()` =/= `Gradient.value()` and the Hessian returning incorrect results - MREs below:

```py
import sleipnir.autodiff as ad
from sleipnir.autodiff import Gradient, Variable

x = Variable()
x.set_value(3.0)
f = ad.abs(x * x - 4.0)

symbolic_before = Gradient(f, x).get().value()[0, 0]
numeric = Gradient(f, x).value()[0, 0]
symbolic_after = Gradient(f, x).get().value()[0, 0]

print(symbolic_before) # prints 0.0
print(numeric) # prints 6.0
print(symbolic_after) # prints 6.0
```
```py
import numpy as np
import sleipnir.autodiff as ad
from sleipnir.autodiff import Hessian, VariableMatrix

variables = VariableMatrix(2)
x, y = variables[0], variables[1]
x.set_value(2.0)
y.set_value(1.0)
f = ad.min(x * x, y * y)

# min(x², y²) is y² at (2, 1).
print(np.asarray(Hessian(f, variables).value().todense()))

# This prints diag([2, 0]), not diag([0, 2]).
```

```py
import numpy as np
import sleipnir.autodiff as ad
from sleipnir.autodiff import Hessian, VariableMatrix

variables = VariableMatrix(2)
x, y = variables[0], variables[1]
x.set_value(2.0)
y.set_value(3.0)
f = ad.pow(x + 1.0, y)

actual = np.asarray(Hessian(f, variables).value().todense())
mixed = 9.0 * (1.0 + 3.0 * np.log(3.0))
expected = np.array(
    [
        [18.0, mixed],
        [mixed, 27.0 * np.log(3.0) ** 2],
    ]
)

print(actual)
print(expected)

# actual is [    18  38.66 ]
#           [     1      0 ]
# expected  [    18  38.66 ]
#           [ 38.66  32.58 ]
```

For min and max I made a new expression type so that there would be a single node to evaluate against instead of a chain of nodes to help with performance although I'm not sure how large the difference would be in practice. I didn't do the same for the fix to pow() due to the required length but it could be done (might be worth doing since pow is likely more commonly used?)

I also added the MREs I used to the test suite.