### PR TITLE
Fix invalid constant pruning for atan2 and hypot

### DIFF
--- a/include/sleipnir/autodiff/expression.hpp
+++ b/include/sleipnir/autodiff/expression.hpp
@@ -1043,14 +1043,6 @@ ExpressionPtr<Scalar> atan2(const ExpressionPtr<Scalar>& y,
   using enum ExpressionType;
   using std::atan2;
 
-  // Prune expression
-  if (y->is_constant(Scalar(0))) {
-    // Return zero, which y currently is
-    return y;
-  } else if (x->is_constant(Scalar(0))) {
-    return constant_ptr(Scalar(std::numbers::pi) / Scalar(2));
-  }
-
   // Evaluate constant
   if (y->type() == CONSTANT && x->type() == CONSTANT) {
     return constant_ptr(atan2(y->val, x->val));
@@ -1339,9 +1331,9 @@ ExpressionPtr<Scalar> hypot(const ExpressionPtr<Scalar>& x,
 
   // Prune expression
   if (x->is_constant(Scalar(0))) {
-    return y;
+    return abs(y);
   } else if (y->is_constant(Scalar(0))) {
-    return x;
+    return abs(x);
   }
 
   // Evaluate constant

--- a/test/src/autodiff/expression_test.cpp
+++ b/test/src/autodiff/expression_test.cpp
@@ -177,11 +177,16 @@ TEMPLATE_TEST_CASE("Expression - Prune atan2()", "[Expression]",
   using T = TestType;
   using std::atan2;
 
+  auto negative_one = constant_ptr(T(-1));
   auto zero = constant_ptr(T(0));
   auto one = constant_ptr(T(1));
 
   CHECK(slp::detail::atan2(zero, one)->is_constant(T(0)));
   CHECK(slp::detail::atan2(one, zero)->is_constant(T(std::numbers::pi / 2)));
+  CHECK(
+      slp::detail::atan2(zero, negative_one)->is_constant(atan2(T(0), T(-1))));
+  CHECK(
+      slp::detail::atan2(negative_one, zero)->is_constant(atan2(T(-1), T(0))));
   CHECK(slp::detail::atan2(one, one)->is_constant(atan2(T(1), T(1))));
 }
 
@@ -255,13 +260,19 @@ TEMPLATE_TEST_CASE("Expression - Prune exp()", "[Expression]",
 TEMPLATE_TEST_CASE("Expression - Prune hypot()", "[Expression]",
                    SCALAR_TYPES_UNDER_TEST) {
   using T = TestType;
+  using std::hypot;
 
+  auto negative_one = constant_ptr(T(-1));
   auto zero = constant_ptr(T(0));
   auto one = constant_ptr(T(1));
 
   CHECK(slp::detail::hypot(zero, zero)->is_constant(T(0)));
-  CHECK(slp::detail::hypot(zero, one) == one);
-  CHECK(slp::detail::hypot(one, zero) == one);
+  CHECK(slp::detail::hypot(zero, one)->is_constant(T(1)));
+  CHECK(slp::detail::hypot(one, zero)->is_constant(T(1)));
+  CHECK(
+      slp::detail::hypot(zero, negative_one)->is_constant(hypot(T(0), T(-1))));
+  CHECK(
+      slp::detail::hypot(negative_one, zero)->is_constant(hypot(T(-1), T(0))));
   CHECK(slp::detail::hypot(one, one)->is_constant(T(std::numbers::sqrt2)));
 }
 

--- a/test/src/autodiff/gradient_test.cpp
+++ b/test/src/autodiff/gradient_test.cpp
@@ -492,6 +492,14 @@ TEMPLATE_TEST_CASE("Gradient - atan2()", "[Gradient]",
       g.value().coeff(0),
       WithinAbs(T(-2) / (T(2) * T(2) + x.value() * x.value()), T(1e-15)));
 
+  // Testing atan2 function on (0, var)
+  x.set_value(T(-2));
+  CHECK(slp::atan2(T(0), x).value() == atan2(T(0), x.value()));
+
+  g = slp::Gradient(slp::atan2(T(0), x), x);
+  CHECK(g.get().value().coeff(0) == T(0));
+  CHECK(g.value().coeff(0) == T(0));
+
   // Testing atan2 function on (var, T)
   x.set_value(T(1));
   y.set_value(T(0.9));
@@ -502,6 +510,14 @@ TEMPLATE_TEST_CASE("Gradient - atan2()", "[Gradient]",
              WithinAbs(T(2) / (T(2) * T(2) + x.value() * x.value()), T(1e-15)));
   CHECK_THAT(g.value().coeff(0),
              WithinAbs(T(2) / (T(2) * T(2) + x.value() * x.value()), T(1e-15)));
+
+  // Testing atan2 function on (var, 0)
+  x.set_value(T(-2));
+  CHECK(slp::atan2(x, T(0)).value() == atan2(x.value(), T(0)));
+
+  g = slp::Gradient(slp::atan2(x, T(0)), x);
+  CHECK(g.get().value().coeff(0) == T(0));
+  CHECK(g.value().coeff(0) == T(0));
 
   // Testing atan2 function on (var, var)
   x.set_value(T(1.1));
@@ -579,12 +595,28 @@ TEMPLATE_TEST_CASE("Gradient - hypot()", "[Gradient]",
   CHECK(g.get().value().coeff(0) == x.value() / hypot(x.value(), T(2)));
   CHECK(g.value().coeff(0) == x.value() / hypot(x.value(), T(2)));
 
+  // Testing hypot function on (var, 0)
+  x.set_value(T(-1));
+  CHECK(slp::hypot(x, T(0)).value() == hypot(x.value(), T(0)));
+
+  g = slp::Gradient(slp::hypot(x, T(0)), x);
+  CHECK(g.get().value().coeff(0) == T(-1));
+  CHECK(g.value().coeff(0) == T(-1));
+
   // Testing hypot function on (T, var)
   CHECK(slp::hypot(T(2), y).value() == hypot(T(2), y.value()));
 
   g = slp::Gradient(slp::hypot(T(2), y), y);
   CHECK(g.get().value().coeff(0) == y.value() / hypot(T(2), y.value()));
   CHECK(g.value().coeff(0) == y.value() / hypot(T(2), y.value()));
+
+  // Testing hypot function on (0, var)
+  y.set_value(T(-2));
+  CHECK(slp::hypot(T(0), y).value() == hypot(T(0), y.value()));
+
+  g = slp::Gradient(slp::hypot(T(0), y), y);
+  CHECK(g.get().value().coeff(0) == T(-1));
+  CHECK(g.value().coeff(0) == T(-1));
 
   // Testing hypot function on (var, var)
   x.set_value(T(1.3));


### PR DESCRIPTION
The pruning for atan2 and hypot was producing incorrect results depending on the sign of the inputs. Specifically, hypot was missing use of `abs` for constant-zero-pruning and atan2 has different results depending on the sign of the other argument, so we cannot constant-prune unless both arguments are constant (which is already covered). Added expression tests and gradient tests to cover this case as well although I'm not sure if the gradient tests are actually necessary here.

MRE for atan2:
```py
import math

from sleipnir import autodiff
from sleipnir.optimization import Problem, bounds

problem = Problem()

x = problem.decision_variable()
x.set_value(-2.0)

problem.minimize(autodiff.pow(x - autodiff.atan2(x, 0.0), 2))
problem.subject_to(bounds(-3.0, x, -1.0))

print(f"cost type: {problem.cost_function_type()}")

status = problem.solve()

print(f"status: {status}")
print(f"x: {x.value()}")
```
Before:
cost type: ExpressionType.QUADRATIC
status: ExitStatus.SUCCESS
x: approx -1

After:
cost type: ExpressionType.NONLINEAR
status: ExitStatus.SUCCESS
x: -1.570796328116714

MRE for hypot:
```py
from sleipnir import autodiff
from sleipnir.optimization import Problem, bounds

problem = Problem()

x = problem.decision_variable()
x.set_value(-2.0)

# hypot(x, 0) = abs(x) which has minimum x = -1 on [-3, -1].
problem.minimize(autodiff.hypot(x, 0.0))
problem.subject_to(bounds(-3.0, x, -1.0))

print(f"cost type: {problem.cost_function_type()}")

status = problem.solve()

print(f"status: {status}")
print(f"x: {x.value()}")
 ```
Before:
cost type: ExpressionType.LINEAR
status: ExitStatus.SUCCESS
x: approx -3

After:
cost type: ExpressionType.NONLINEAR
status: ExitStatus.SUCCESS
x: approx -1