### PR TITLE
Fix feasibility restoration dropping constraint curvature

### DIFF
--- a/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
+++ b/include/sleipnir/optimization/solver/util/feasibility_restoration.hpp
@@ -228,7 +228,7 @@ ExitStatus feasibility_restoration(
         //
         //   −∇ₓₓ²yᵀcₑ(x)
         auto H_c = matrices.H_c(x, y);
-        H_c.resize(x_p.rows(), x_p.rows());
+        H_c.conservativeResize(x_p.rows(), x_p.rows());
 
         // Lagrangian Hessian
         //
@@ -483,7 +483,7 @@ ExitStatus feasibility_restoration(
         //
         //   −∇ₓₓ²yᵀcₑ(x) − ∇ₓₓ²zᵀcᵢ(x)
         auto H_c = matrices.H_c(x, y, z);
-        H_c.resize(x_p.rows(), x_p.rows());
+        H_c.conservativeResize(x_p.rows(), x_p.rows());
 
         // Lagrangian Hessian
         //

--- a/test/src/optimization/cart_pole_problem_test.cpp
+++ b/test/src/optimization/cart_pole_problem_test.cpp
@@ -31,12 +31,12 @@ TEMPLATE_TEST_CASE("Problem - Cart-pole", "[Problem]",
   slp::scope_exit exit{
       [] { CHECK(slp::global_pool_resource().blocks_in_use() == 0u); }};
 
-  constexpr std::chrono::duration<T> TOTAL_TIME{T(5)};
+  constexpr std::chrono::duration<T> TOTAL_TIME{T(3.5)};
   constexpr std::chrono::duration<T> dt{T(0.05)};
   constexpr int N = static_cast<int>(TOTAL_TIME / dt);
 
   constexpr T u_max(20);  // N
-  constexpr T d_max(2);   // m
+  constexpr T d_max(1);   // m
 
   constexpr Eigen::Vector<T, 4> x_initial{{T(0), T(0), T(0), T(0)}};
   constexpr Eigen::Vector<T, 4> x_final{

--- a/test/src/optimization/cart_pole_problem_test.cpp
+++ b/test/src/optimization/cart_pole_problem_test.cpp
@@ -31,12 +31,12 @@ TEMPLATE_TEST_CASE("Problem - Cart-pole", "[Problem]",
   slp::scope_exit exit{
       [] { CHECK(slp::global_pool_resource().blocks_in_use() == 0u); }};
 
-  constexpr std::chrono::duration<T> TOTAL_TIME{T(3.5)};
+  constexpr std::chrono::duration<T> TOTAL_TIME{T(5)};
   constexpr std::chrono::duration<T> dt{T(0.05)};
   constexpr int N = static_cast<int>(TOTAL_TIME / dt);
 
   constexpr T u_max(20);  // N
-  constexpr T d_max(1);   // m
+  constexpr T d_max(2);   // m
 
   constexpr Eigen::Vector<T, 4> x_initial{{T(0), T(0), T(0), T(0)}};
   constexpr Eigen::Vector<T, 4> x_final{


### PR DESCRIPTION
Matrix.resize is destructive meaning the restoration runs without second order constraint information. Also modified the cart pole problem test to act as a regression test.